### PR TITLE
Fix weird issue where data in the backtrace is bogus

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -76,6 +76,7 @@ module BetterErrors
       lines = File.readlines(frame.filename)
       min_line = [1, frame.line - lines_of_context].max - 1
       max_line = [frame.line + lines_of_context, lines.count + 1].min - 1
+      raise Errno::EINVAL if min_line > lines.length
       [min_line, max_line, lines[min_line..max_line].join]
     end
     
@@ -96,7 +97,7 @@ module BetterErrors
         end
         html << "</div>"
       end
-    rescue Errno::ENOENT
+    rescue Errno::ENOENT, Errno::EINVAL
       "<p>Source unavailable</p>"
     end
   end


### PR DESCRIPTION
Ruby appears to send backtraces with bad line numbers (IE, a larger number
than the number of lines in the file) in certain cases.

For instance one of the lines in my backtrace is this:

```
<my rbenv path>/lib/ruby/gems/1.9.1/gems/http_router-0.10.2/lib/http_router/node/root.rb:156:in `[]'
```

However, [http_router/node/root.rb](https://github.com/joshbuddy/http_router/blob/master/lib/http_router/node/root.rb) only has 141 lines.

This patch adds a check so that the better_errors code doesn't itself raise an uncaught exception when this occurs.

-David
