### PR TITLE
Hide better_errors request logs.

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -6,6 +6,7 @@ require "better_errors/version"
 require "better_errors/error_page"
 require "better_errors/stack_frame"
 require "better_errors/middleware"
+require "better_errors/disable_logging_middleware"
 require "better_errors/code_formatter"
 require "better_errors/repl"
 

--- a/lib/better_errors/disable_logging_middleware.rb
+++ b/lib/better_errors/disable_logging_middleware.rb
@@ -1,0 +1,15 @@
+module BetterErrors
+  class DisableLoggingMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      original_level = BetterErrors.logger.level
+      BetterErrors.logger.level = Logger::ERROR if env['PATH_INFO'].index("/__better_errors") == 0
+      @app.call(env)
+    ensure
+      BetterErrors.logger.level = original_level
+    end
+  end
+end

--- a/lib/better_errors/rails.rb
+++ b/lib/better_errors/rails.rb
@@ -3,6 +3,7 @@ module BetterErrors
     initializer "better_errors.configure_rails_initialization" do
       unless Rails.env.production?
         Rails.application.middleware.use BetterErrors::Middleware
+        Rails.application.middleware.insert_before Rails::Rack::Logger, BetterErrors::DisableLoggingMiddleware
         BetterErrors.logger = Rails.logger
         BetterErrors.application_root = Rails.root.to_s
       end


### PR DESCRIPTION
I thought it would nicer if `better_errors` requests don't show up in the Rails logs. I don't know if you think that's a good idea, but I quickly got tired of seeing lines like:

```
Started POST "/__better_errors/38256880/variables" for 127.0.0.1 at 2012-12-12 00:14:00 +1300
```
