### PR TITLE
Add links to open files in the user's editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ get "/" do
 end
 ```
 
+## Open-in-Editor functionality
+
+File links will open in TextMate by default, using the `txmt` URL scheme.  You can supply a custom proc to generate the URL
+for your preferred editor :
+
+```ruby
+BetterErrors.editor = Proc.new{|file, line| "mvim://open/?url=file://#{URI.escape file}&line=#{line}"}
+```
+
 ## Compatibility
 
 * **Supported**

--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -11,9 +11,18 @@ require "better_errors/code_formatter"
 require "better_errors/repl"
 
 class << BetterErrors
-  attr_accessor :application_root, :binding_of_caller_available, :logger
+  attr_accessor :application_root, :binding_of_caller_available, :logger, :editor
   
   alias_method :binding_of_caller_available?, :binding_of_caller_available
+
+  # generate a URL to open the user's editor with a specified file & line number
+  def editor_url(file, line)
+    editor.call(file, line)
+  end
+  def editor
+    # default to opening files in TextMate
+    @editor || Proc.new{|file, line| "txmt://open/?url=file://#{URI.escape file}&line=#{line}"}
+  end
 end
 
 begin

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -683,7 +683,7 @@
                 <header class="trace_info">
                     <div class="title">
                         <h2 class="name"><%= frame.name %></h2>
-                        <div class="location"><span class="filename"><%= frame.pretty_path %></span></div>
+                        <div class="location"><span class="filename"><a href="<%= BetterErrors.editor_url(frame.filename, frame.line) %>"><%= frame.pretty_path %></a></span></div>
                     </div>
                     
                     <%== highlighted_code_block frame %>


### PR DESCRIPTION
Hi - this commit replaces the file name (at the top of the trace_info panel) with a link that will open the file in the user's editor.  It defaults to opening links in textmate using the txmt handler, but you could override it in an initializer using something like : 

``` ruby
if defined?(BetterErrors)
  BetterErrors.editor = Proc.new{|file, line| "mvim://open/?url=file://#{URI.escape file}&line=#{line}"}
end
```

Possible improvements might be to try & guess the appropriate url based on the user's $EDITOR var, but maybe this is good enough for now.   I'd also wondered about changing the filenames in the left-hand stacktrace column into links, but it does then make it a bit more difficult to click on a particular frame.

What do you think?
