### PR TITLE
Bugfix for StackFrame#context

### DIFF
--- a/lib/better_errors/stack_frame.rb
+++ b/lib/better_errors/stack_frame.rb
@@ -63,10 +63,10 @@ module BetterErrors
     end
     
     def context
-      if application?
-        :application
-      elsif gem?
+      if gem?
         :gem
+      elsif application?
+        :application
       else
         :dunno
       end


### PR DESCRIPTION
StackFrame#context gets confused for files belonging to a gem located beneath the application root. This is common on "deployment" bundler setups which installs the gems to vendor/bundle.
