### PR TITLE
Use PATH_INFO instead of REQUEST_PATH on error page

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -81,7 +81,7 @@ module BetterErrors
     end
   
     def request_path
-      env["REQUEST_PATH"]
+      env["PATH_INFO"]
     end
     
     def highlighted_code_block(frame)

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -4,7 +4,7 @@ module BetterErrors
   describe ErrorPage do
     let!(:exception) { raise ZeroDivisionError, "you divided by zero you silly goose!" rescue $! }
   
-    let(:error_page) { ErrorPage.new exception, { "REQUEST_PATH" => "/some/path" } }
+    let(:error_page) { ErrorPage.new exception, { "PATH_INFO" => "/some/path" } }
     
     let(:response) { error_page.render }
     


### PR DESCRIPTION
The request path wasn't appearing in my error pages (using Pow), so here's a fix. I made a couple other changes as well to improve the specs. Thanks for this project!
