### PR TITLE
Move responsibility of knowing editor scheme into the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,17 @@ end
 
 ## Open-in-Editor functionality
 
-File links will open in TextMate by default, using the `txmt` URL scheme.  You can supply a custom proc to generate the URL
-for your preferred editor :
+File links will open in TextMate by default.  You can supply your preferred editor like this:
 
 ```ruby
-BetterErrors.editor = Proc.new{|file, line| "mvim://open/?url=file://#{URI.escape file}&line=#{line}"}
+if defined?(BetterErrors) && BetterErrors.respond_to?(:editor=)
+  BetterErrors.editor = :subl
+end
 ```
+
+Currently supported editors are: `:textmate`, `:sublime`, `:mvim`
+
+If you're in a team that uses different editors, you can supply the editor in a file that is not checked into your repository.
 
 ## Compatibility
 

--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -14,11 +14,6 @@ class << BetterErrors
   attr_accessor :application_root, :binding_of_caller_available, :logger, :editor
   
   alias_method :binding_of_caller_available?, :binding_of_caller_available
-  
-  def editor
-    # default to opening files in TextMate
-    @editor || proc { |file, line| "txmt://open/?url=file://#{URI.encode_www_form_component(file)}&line=#{line}" }
-  end
 end
 
 begin

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -53,7 +53,16 @@ module BetterErrors
     
   private
     def editor_url(frame)
-      BetterErrors.editor[frame.filename, frame.line]
+      file = URI.encode_www_form_component(frame.filename)
+      line = frame.line
+      return case BetterErrors.editor.to_s.downcase
+      when "sublime", "sublime text", "sublime text 2", "subl"
+        "subl://open/?url=file://#{file}&line=#{line}"
+      when "macvim", "mvim"
+        "mvim://open/?url=file://#{file}&line=#{line}"
+      else
+        "txmt://open/?url=file://#{file}&line=#{line}"
+      end
     end
     
     def rack_session

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -56,5 +56,15 @@ module BetterErrors
       ])
       response.should include("Source unavailable")
     end
+
+    describe "#editor_url" do
+      let(:filename) { "/some/file/somewhere" }
+      let(:line) { "123" }
+      let(:frame) { mock(:filename => filename, :line => line) }
+
+      it "defaults to Textmate" do
+        error_page.send(:editor_url, frame).should eq("txmt://open/?url=file://#{URI.encode_www_form_component(filename)}&line=#{line}")
+      end
+    end
   end
 end


### PR DESCRIPTION
Instead of developers providing a `proc` with URL-scheme for their editor, they just provide a name.

Hence, the gem will have to _support_ editors.
