### PR TITLE
binding_of_caller warning

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -29,12 +29,6 @@ rescue LoadError => e
   BetterErrors.binding_of_caller_available = false
 end
 
-unless BetterErrors.binding_of_caller_available?
-  warn "BetterErrors: binding_of_caller gem unavailable, cannot display local variables on error pages."
-  warn "Add 'binding_of_caller' to your Gemfile to make this warning go away."
-  warn ""
-end
-
 require "better_errors/core_ext/exception"
 
 require "better_errors/rails" if defined? Rails::Railtie


### PR DESCRIPTION
The binding_of_caller warning is not appropriate. Some people use jruby and cannot install it or may just not want to have that gem installed. This makes the warning annoying. The lack of presence from this gem is not something you should be warning developers about. :relaxed: 

Great work! If this pull request is accepted then I would consider putting this into every one of my ruby projects as apart of the standard new template. 

Lets just remove this warning especially since some dev's cannot even install the gem because of their selected ruby.
