### PR TITLE
fix bug: throw 404 when OID get a native number in templates/main.erb

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -51,7 +51,7 @@ module BetterErrors
     end
   
     def internal_call(env, opts)
-      if opts[:oid].to_i != @error_page.object_id
+      if opts[:oid].to_i != @error_page.object_id.abs
         return [200, { "Content-Type" => "text/plain; charset=utf-8" }, [JSON.dump(error: "Session expired")]]
       end
       

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -703,7 +703,7 @@
 </body>
 <script>
 (function() {
-    var OID = <%== object_id.to_s.inspect %>;
+    var OID = <%== object_id.abs.to_s.inspect %>;
     
     var previousFrame = null;
     var previousFrameInfo = null;


### PR DESCRIPTION
i find main.erb will send a http request to  `/__better_errors/OID/<method>`, OID was `ErrorPage#__id__`,  but when OID is a native number, example: `__better_errors/-283746883/variables` we get a 404 `NO ROUTE` expection.
