### PR TITLE
Better Rails 3.0 compatibility

### DIFF
--- a/better_errors.gemspec
+++ b/better_errors.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   s.add_development_dependency "yard"
   
-  s.add_dependency "erubis", ">= 2.7.0"
+  s.add_dependency "erubis", ">= 2.6.6"
   s.add_dependency "coderay", ">= 1.0.0"
 
   # optional dependencies:


### PR DESCRIPTION
Since latest 3.0 Rails version (Rails 3.0.17) depends on erubis ~> 2.6.6, it is not usable with better_errors gem now.

I tried erubis 2.6.6 locally with my big Rails 3.0.17 project without problems with custom better_errors gemspec. I tried some travis tests also - https://travis-ci.org/simi/better_errors/builds/3803034. I'm new into better_errors, so I'm not sure if those JRuby and RBX tests are allowed to fail now. But those errors are same for erubis 2.7.0 and erubis 2.6.6.

Happy Christmas and thank you for this nice gem.
