### PR TITLE
Add .travis.yml for Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+rvm:
+  - '1.9.2'
+  - '1.8.7'
+  - '1.9.3'
+  - jruby
+script: bundle exec rspec


### PR DESCRIPTION
Seeing how awesome this gem is, I'd love to use the latest git version of it in my application, but I'm not sure if it's working or not.

This pull request includes a `.travis.yml` file to allow continuos builds on push by [Travis CI](http://travis-ci.org)

Please refer to steps 1. and 2. of ["Getting started" guide](http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in) to enable builds in Travis
