### PR TITLE
Rewind rack.input before reading from it

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -109,7 +109,8 @@ module BetterErrors
       if opts[:oid].to_i != @error_page.object_id
         return [200, { "Content-Type" => "text/plain; charset=utf-8" }, [JSON.dump(error: "Session expired")]]
       end
-      
+
+      env["rack.input"].rewind
       response = @error_page.send("do_#{opts[:method]}", JSON.parse(env["rack.input"].read))
       [200, { "Content-Type" => "text/plain; charset=utf-8" }, [JSON.dump(response)]]
     end


### PR DESCRIPTION
If there is a middleware before better_errors, it may read from env['rack.input'] and leave it in eof state, thus causing better_errors to get a JSON parse error on an empty string.
This rewinds rack.input before reading from it, may fix #93, #84.
