### PR TITLE
Change middleware to support rails app in subfolders

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -58,9 +58,9 @@ module BetterErrors
 
     def better_errors_call(env)
       case env["PATH_INFO"]
-      when %r{\A/__better_errors/(?<oid>-?\d+)/(?<method>\w+)\z}
+      when %r{\A.*/__better_errors/(?<oid>-?\d+)/(?<method>\w+)\z}
         internal_call env, $~
-      when %r{\A/__better_errors/?\z}
+      when %r{\A.*/__better_errors/?\z}
         show_error_page env
       else
         protected_app_call env

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -13,9 +13,19 @@ module BetterErrors
       app.call("PATH_INFO" => "/__better_errors/1/preform_awesomness")
     end
 
+    it "should call the internal methods on any subfolder path" do
+      app.should_receive :internal_call
+      app.call("PATH_INFO" => "/any_sub/folder/path/__better_errors/1/preform_awesomness")
+    end
+
     it "should show the error page" do
       app.should_receive :show_error_page
       app.call("PATH_INFO" => "/__better_errors/")
+    end
+
+    it "should show the error page on any subfolder path" do
+      app.should_receive :show_error_page
+      app.call("PATH_INFO" => "/any_sub/folder/path/__better_errors/")
     end
 
     it "should not show the error page to a non-local address" do
@@ -28,6 +38,11 @@ module BetterErrors
       
       it "should show that no errors have been recorded" do
         status, headers, body = app.call("PATH_INFO" => "/__better_errors")
+        body.join.should match /No errors have been recorded yet./
+      end
+
+      it "should show that no errors have been recorded on any subfolder path" do
+        status, headers, body = app.call("PATH_INFO" => "/any_sub/folder/path/__better_errors")
         body.join.should match /No errors have been recorded yet./
       end
     end


### PR DESCRIPTION
If two applications run on the same domain

first_rails_app -> in http:://any_domain/
second_rails_app -> in http://any_domain/seccond_application

and in the second one a error is occured then "__better_errors" from the second app should be called.

To provide this the regular expression for the better_errors_call-Method should listen on any "__better_errors" string on any page.
