### PR TITLE
Insert BetterErrors rack middleware after ActionDispatch::DebugExceptions in the railtie

### DIFF
--- a/lib/better_errors/rails.rb
+++ b/lib/better_errors/rails.rb
@@ -3,7 +3,7 @@ module BetterErrors
   class Railtie < Rails::Railtie
     initializer "better_errors.configure_rails_initialization" do
       unless Rails.env.production?
-        Rails.application.middleware.insert_after ActionDispatch::ShowExceptions, BetterErrors::Middleware
+        Rails.application.middleware.insert_after ActionDispatch::DebugExceptions, BetterErrors::Middleware
         BetterErrors.logger = Rails.logger
         BetterErrors.application_root = Rails.root.to_s
       end


### PR DESCRIPTION
Insert `BetterErrors::Middleware` Rack middleware after `ActionDispatch::DebugExceptions` in the Rails railtie.

There are multiple reasons for moving the middleware position:
- Better Errors will work even for exceptions thrown from rack middlewares (actiondispatch etc)
- Other error monitoring services (eg. [Bugsnag](https://bugsnag.com)) will still be called before showing the Better Errors page
- Being a good Rack citizen ;)

This change should be backward compatible.
