### PR TITLE
Hovering over exception header causes a 1px shift

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -147,7 +147,6 @@
     header.exception h2,
     header.exception p {
         line-height: 1.4em;
-        height: 1.4em;
         overflow: hidden;
         white-space: pre;
         text-overflow: ellipsis;


### PR DESCRIPTION
When hovering over the exception header, the exception 
message shifts up by one pixel.
