### PR TITLE
Added option for allow_remote requests

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -109,7 +109,17 @@ module BetterErrors
   def self.use_pry!
     REPL::PROVIDERS.unshift const: :Pry, impl: "better_errors/repl/pry"
   end
-  
+
+  # Allows displaying better errors to remote ip addresses (useful for
+  # Vagrant and remote setups)
+  def self.allow_remote
+    @allow_remote
+  end
+
+  def self.allow_remote=(allow_remote=false)
+    @allow_remote = allow_remote
+  end
+
   BetterErrors.editor = :textmate
 end
 

--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -37,7 +37,7 @@ module BetterErrors
     # @param [Hash] env
     # @return [Array]
     def call(env)
-      if local_request? env
+      if local_request? env or BetterErrors.allow_remote
         better_errors_call env
       else
         @app.call env


### PR DESCRIPTION
Fixes issue #99.

To enable set: 

``` ruby
BetterErrors.allow_remote = true
```
