### PR TITLE
Set default editor to ENV['EDITOR'].

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -110,7 +110,7 @@ module BetterErrors
     REPL::PROVIDERS.unshift const: :Pry, impl: "better_errors/repl/pry"
   end
   
-  BetterErrors.editor = :textmate
+  BetterErrors.editor = (ENV['EDITOR'] && ENV['EDITOR'].to_sym) || :textmate
 end
 
 begin

--- a/spec/better_errors_spec.rb
+++ b/spec/better_errors_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe BetterErrors do
   context ".editor" do
-    it "should default to textmate" do
+    it "should default to $EDITOR" do
       subject.editor["foo.rb", 123].should == "txmt://open?url=file://foo.rb&line=123"
     end
     

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV['EDITOR'] = 'textmate'
+
 require "simplecov"
 SimpleCov.start
 


### PR DESCRIPTION
Developer may choose different editor. So IMO it may be good to pick editor setting from env by default.
