### PR TITLE
invalid addr issue

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -61,11 +61,20 @@ module BetterErrors
 
   private
 
+    # Allows manual setting of the remote address. Valuable when your
+    # development stack is not setting REMOTE_ADDR properly.
+    #
+    # @parse [Hash] env
+    # @return [String]
+    def remote_addr(env)
+      ENV["REMOTE_ADDR"] || env["REMOTE_ADDR"]
+    end
+
     def allow_ip?(env)
       # REMOTE_ADDR is not in the rack spec, so some application servers do
       # not provide it.
-      return true unless env["REMOTE_ADDR"]
-      ip = IPAddr.new env["REMOTE_ADDR"]
+      return true unless remote_addr(env)
+      ip = IPAddr.new remote_addr(env)
       ALLOWED_IPS.any? { |subnet| subnet.include? ip }
     end
 


### PR DESCRIPTION
Puma with nginx (yes that's my local dev env) is not setting the `REMOTE_ADDR` for some reason. A PR exists that checks if it's an empty string but I think a better way to go for 'security!' is to always check that it is being set and set it manually if your dev env is pickled in some way using environment variables.

It could be an option to remove this line completely:

``` ruby
return true unless remote_addr(env)
```
