### PR TITLE
Ignore some instance variables

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -32,8 +32,13 @@ module BetterErrors
     
     # @private
     alias_method :binding_of_caller_available?, :binding_of_caller_available
+
+    # The ignored instance variables.
+    # @return [Array]
+    attr_accessor :ignored_instance_variables
   end
-  
+  @ignored_instance_variables = []
+
   # Returns a proc, which when called with a filename and line number argument,
   # returns a URL to open the filename and line in the selected editor.
   # 

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -4,16 +4,6 @@ require "json"
 module BetterErrors
   # @private
   class ErrorPage
-    @@ignored_instance_variables = []
-
-    def self.ignored_instance_variables
-      @@ignored_instance_variables
-    end
-
-    def self.ignored_instance_variables=(ignored_instance_variables)
-      @@ignored_instance_variables = ignored_instance_variables
-    end
-
     def self.template_path(template_name)
       File.expand_path("../templates/#{template_name}.erb", __FILE__)
     end

--- a/lib/better_errors/stack_frame.rb
+++ b/lib/better_errors/stack_frame.rb
@@ -101,7 +101,7 @@ module BetterErrors
     end
 
     def visible_instance_variables
-      frame_binding.eval("instance_variables") - BetterErrors::ErrorPage.ignored_instance_variables
+      frame_binding.eval("instance_variables") - BetterErrors.ignored_instance_variables
     end
 
     def to_s

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -50,7 +50,7 @@ module BetterErrors
       end
 
       it "should show filter instance variables" do
-        BetterErrors::ErrorPage.stub(:ignored_instance_variables).and_return([ :@inst_d ])
+        BetterErrors.stub(:ignored_instance_variables).and_return([ :@inst_d ])
         html = error_page.do_variables("index" => 0)[:html]
         html.should include("inst_c")
         html.should include(":value_for_inst_c")


### PR DESCRIPTION
Here is a feature to ignore some instance variables on the error page.

It can be used like this (in a Rails initializer for instance):

``` ruby
if defined?(BetterErrors) && Rails.env.development?
  BetterErrors::ErrorPage.ignored_instance_variables += [ :@_request ]
end
```
