### PR TITLE
Test against Ruby 1.9.2, 1.9.3, and 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-    - 2.0.0-rc2
+  - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ end
   * JRuby (1.9 mode) - *advanced features unsupported*
   * Rubinius (1.9 mode) - *advanced features unsupported*
 
+[![Build Status](https://travis-ci.org/charliesome/better_errors.png)](https://travis-ci.org/charliesome/better_errors)
+
 ## Get in touch!
 
 If you're using better_errors, I'd love to hear from you. Drop me a line and tell me what you think!


### PR DESCRIPTION
- Use secure Rubygems URL to avoid Bundler warnings like:

> The source :rubygems is deprecated because HTTP requests are insecure.
> Please change your source to 'https://rubygems.org' if possible, or
> 'http://rubygems.org' if not.
- Add Travis image to README near support information.
