### PR TITLE
Adjust the backtrace to look more like rails. Adds the enhancement requested in #29.

### DIFF
--- a/lib/better_errors/stack_frame.rb
+++ b/lib/better_errors/stack_frame.rb
@@ -50,7 +50,7 @@ module BetterErrors
     def gem_path
       Gem.path.each do |path|
         if filename.index(path) == 0
-          return filename.gsub("#{path}/gems/", "(gem) ")
+          return filename.gsub(%r{#{path}/gems/([^/]+)-([\w.]+)/}, '\1 (\2) ')
         end
       end
     end

--- a/spec/better_errors/stack_frame_spec.rb
+++ b/spec/better_errors/stack_frame_spec.rb
@@ -54,7 +54,7 @@ module BetterErrors
         Gem.stub!(:path).and_return(["/abc/xyz"])
         frame = StackFrame.new("/abc/xyz/gems/whatever-1.2.3/lib/whatever.rb", 123, "foo")
         
-        frame.gem_path.should == "(gem) whatever-1.2.3/lib/whatever.rb"
+        frame.gem_path.should == "whatever (1.2.3) lib/whatever.rb"
       end
       
       it "should prioritize gem path over application path" do
@@ -62,7 +62,7 @@ module BetterErrors
         Gem.stub!(:path).and_return(["/abc/xyz/vendor"])
         frame = StackFrame.new("/abc/xyz/vendor/gems/whatever-1.2.3/lib/whatever.rb", 123, "foo")
         
-        frame.gem_path.should == "(gem) whatever-1.2.3/lib/whatever.rb"
+        frame.gem_path.should == "whatever (1.2.3) lib/whatever.rb"
       end
     end
     


### PR DESCRIPTION
As requested in issue #29, this enhances the backtrace to look more like Rails. It outputs the gem name, it's version (in parentheses) followed by the file path.
