### PR TITLE
Enable support for apps that are run locally at a sub-uri.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,19 @@ Note that the `allow_ip!` is actually backed by a `Set`, so you can add more tha
 
 ## Usage
 
-If you're using Rails, there's nothing else you need to do.
+If you're using Rails, there's nothing else you need to do, unless your
+app is run locally with at a sub-uri ( for instance
+http://localhost:3000/foo/:controller/:action).
+
+```ruby
+module YourApp
+  class Application < Rails::Application
+    # ...
+    config.better_errors.uri_prefix = "/foo"
+    # ...
+  end
+end
+```
 
 If you're not using Rails, you need to insert `BetterErrors::Middleware` into your middleware stack, and optionally set `BetterErrors.application_root` if you'd like Better Errors to abbreviate filenames within your application.
 
@@ -66,13 +78,13 @@ require "better_errors"
 configure :development do
   use BetterErrors::Middleware
   BetterErrors.application_root = File.expand_path("..", __FILE__)
+  # BetterErrors.uri_prefix = "/foo" # Uncomment if your app runs locally at a sub-uri
 end
 
 get "/" do
   raise "oops"
 end
 ```
-
 ## Compatibility
 
 * **Supported**

--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -108,6 +108,18 @@ module BetterErrors
       end
     end
   end
+      
+  # The path the local application is available at. Defaults to "/"
+  # @return [String, nil] 
+  def self.uri_prefix
+    @uri_prefix
+  end
+
+  # Sets the uri_prefix. This is called from the Railtie or can be called directly
+  # in the case of Sinatra or Rack apps.
+  def self.uri_prefix=(uri_prefix)
+    @uri_prefix = uri_prefix.match(/^\//) ? uri_prefix : "/#{uri_prefix}"
+  end
 
   # Enables experimental Pry support in the inline REPL
   #

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -74,7 +74,7 @@ module BetterErrors
     end
 
     def uri_prefix
-      env["SCRIPT_NAME"] || ""
+      BetterErrors.uri_prefix || ENV['SCRIPT_NAME'] || ""
     end
   
     def exception_message

--- a/lib/better_errors/rails.rb
+++ b/lib/better_errors/rails.rb
@@ -1,11 +1,15 @@
 module BetterErrors
   # @private
   class Railtie < Rails::Railtie
+
+    config.better_errors = ActiveSupport::OrderedOptions.new
+
     initializer "better_errors.configure_rails_initialization" do
       if use_better_errors?
         insert_middleware
         BetterErrors.logger = Rails.logger
         BetterErrors.application_root = Rails.root.to_s
+        BetterErrors.uri_prefix = config.better_errors.uri_prefix if config.better_errors.uri_prefix
       end
     end
 

--- a/lib/better_errors/version.rb
+++ b/lib/better_errors/version.rb
@@ -1,3 +1,3 @@
 module BetterErrors
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
For example app_1 runs at dev.co/ and app_2 runs at dev.co/app_2/

If app_2 has BetterErrors installed, the repl will not show up because
it sends its `/__better_errors/...` requests to app_1.

This feature lets the user specify the sub-uri (or as its being called
here uri_prefix) in Rail's configuration block `config.better_error.uri_prefix = "/app_2"`
or by calling it directly `BetterErrors.uri_prefix = "/app_2"`.
