### PR TITLE
Update documentation, regarding allow_ip! and virtualbox users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gem "binding_of_caller"
 
 This is an optional dependency however, and Better Errors will work without it.
 
-## Security
+## Security, VirtualBox
 
 **NOTE:** It is *critical* you put better\_errors in the **development** section. **Do NOT run better_errors in production, or on Internet facing hosts.**
 
@@ -50,6 +50,8 @@ TRUSTED_IP=66.68.96.220 rails s
 Note that the `allow_ip!` is actually backed by a `Set`, so you can add more than one IP address or subnet.
 
 **Tip:** You can find your apparent IP by hitting the old error page's "Show env dump" and looking at "REMOTE_ADDR".
+
+**VirtualBox:** If you are using VirtualBox and are accessing the guestOS from your hostOS's browser, you will need to use the above  ***allow_ip!*** to see the error page.
 
 ## Usage
 


### PR DESCRIPTION
I ran into this problem, where I couldn't see the error page, because I am using Ubuntu inside of virtualbox and attempting to view pages from the hostOS's browser.

This documentation update should save VirtualBox user's some time.
