### PR TITLE
Better Errors supports RBX adv. features now

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ end
 
 * **Supported**
   * MRI 1.9.2, 1.9.3, 2.0.0
+  * Rubinius (1.9 mode) - *advanced features supported with binding_of_caller >= 0.7.2*
   * JRuby (1.9 mode) - *advanced features unsupported*
-  * Rubinius (1.9 mode) - *advanced features unsupported*
 
 [![Build Status](https://travis-ci.org/charliesome/better_errors.png)](https://travis-ci.org/charliesome/better_errors)
 


### PR DESCRIPTION
With the 0.7.2 binding_of_caller release better_errors supports the
advanced features for RBX now
