### PR TITLE
Remove useless float:left for file title

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -420,7 +420,6 @@
     }
 
     .trace_info .title .location {
-        float: left;
         font-weight: bold;
         font-size: 10pt;
     }


### PR DESCRIPTION
Hi,

Every time I want to copy paste the path of the current file, on Chrome, this is buggy and always highlight file name (which is annoying).

This commit fix this.
