### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ end
   * JRuby (1.9 mode) - *advanced features unsupported*
   * Rubinius (1.9 mode) - *advanced features unsupported*
 
-[![Build Status](https://travis-ci.org/charliesome/better_errors.png)](https://travis-ci.org/charliesome/better_errors)
+[![Build Status](https://travis-ci.org/charliesome/better_errors.png)](https://travis-ci.org/charliesome/better_errors) [![Code Climate](https://codeclimate.com/github/charliesome/better_errors.png)](https://codeclimate.com/github/charliesome/better_errors)
 
 ### Unicorn, Puma, and other multi-worker servers
 


### PR DESCRIPTION
Hi,

Just wanted to drop you a note to let you know that someone (perhaps one of you) added Better Errors to Code Climate a while back. (BTW, Better Errors is awesome! I wish it was built in to Rails.)

For those unfamiliar, Code Climate automatically reviews Ruby code for quality using static analysis. I built it and it's free for OSS. The metrics live here:

https://codeclimate.com/github/charliesome/better_errors

If you want this information to be available to contributors, this quick PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA.

I hope you like it. Let me know if I can help with anything.

Hope you find Code Climate useful.

Cheers,
Bryan
