### PR TITLE
Adds method to allow all connections to see better errors

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -29,10 +29,17 @@ module BetterErrors
     # Set to `{ "127.0.0.1/8", "::1/128" }` by default.
     ALLOWED_IPS = Set.new
 
+    @@allow_wildcards = false
+
     # Adds an address to the set of IP addresses allowed to access Better
     # Errors.
     def self.allow_ip!(addr)
       ALLOWED_IPS << IPAddr.new(addr)
+    end
+
+    # Sets a boolean allowing all connections access to Better Errors
+    def self.allow_all_connections!
+      @@allow_wildcards = true
     end
 
     allow_ip! "127.0.0.0/8"
@@ -65,6 +72,7 @@ module BetterErrors
       # REMOTE_ADDR is not in the rack spec, so some application servers do
       # not provide it.
       return true unless env["REMOTE_ADDR"]
+      return true if @@allow_wildcards
       ip = IPAddr.new env["REMOTE_ADDR"]
       ALLOWED_IPS.any? { |subnet| subnet.include? ip }
     end

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -40,6 +40,12 @@ module BetterErrors
       app.call("REMOTE_ADDR" => "77.55.33.11")
     end
 
+    it "shows to all IPs" do
+      BetterErrors::Middleware.allow_all_connections!
+      app.should_receive :better_errors_call
+      app.call("REMOTE_ADDR" => "77.55.33.12")
+    end
+
     context "when requesting the /__better_errors manually" do
       let(:app) { Middleware.new(->env { ":)" }) }
 


### PR DESCRIPTION
This pull request adds a new class method to the middleware class that specifies allowing all connections the ability to view Better Errors. Rather than whitelisting IPs for teams, this method can be called in the dev environment.rb file switching Better Errors on for all connections. Use case is using remote servers (i.e. AWS) as the dev and staging environments and allowing multiple people on a team access to the boxes. Whitelisting IPs can be cumbersome for large teams.
