### PR TITLE
Consolidate possible editor presets

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -12,7 +12,7 @@ require "better_errors/repl"
 
 module BetterErrors
   POSSIBLE_EDITOR_PRESETS = [
-    { symbols: [:emacs],                sniff: /emacs/i, url: "emacs://open?url=file://%{file}&line=%{line}" },
+    { symbols: [:emacs, :emacsclient],  sniff: /emacs/i, url: "emacs://open?url=file://%{file}&line=%{line}" },
     { symbols: [:macvim, :mvim],        sniff: /vim/i,   url: proc { |file, line| "mvim://open?url=file://#{file}&line=#{line}" } },
     { symbols: [:sublime, :subl, :st],  sniff: /subl/i,  url: "subl://open?url=file://%{file}&line=%{line}" },
     { symbols: [:textmate, :txmt, :tm], sniff: /mate/i,  url: "txmt://open?url=file://%{file}&line=%{line}" },

--- a/spec/better_errors_spec.rb
+++ b/spec/better_errors_spec.rb
@@ -10,7 +10,7 @@ describe BetterErrors do
       subject.editor["&.rb", 0].should == "txmt://open?url=file://%26.rb&line=0"
     end
 
-    [:emacs].each do |editor|
+    [:emacs, :emacsclient].each do |editor|
       it "uses emacs:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
         subject.editor[].should start_with "emacs://"


### PR DESCRIPTION
Refactored editor selection behaviors so that when a new editor is added or an existing one is modified, future changes only need to happen in once place.

I also snuck in a commit to add `:emacsclient` as a possible editor preset symbol for emacs.
