### PR TITLE
Separate line number count from code to allow for copying, closes #42

### DIFF
--- a/lib/better_errors/code_formatter/html.rb
+++ b/lib/better_errors/code_formatter/html.rb
@@ -8,12 +8,19 @@ module BetterErrors
     def formatted_lines
       each_line_of(highlighted_lines) { |highlight, current_line, str|
         class_name = highlight ? "highlight" : ""
-        sprintf '<pre class="%s">%5d %s</pre>', class_name, current_line, str
+        sprintf '<pre class="%s">%s</pre>', class_name, str
+      }
+    end
+    
+    def formatted_nums
+      each_line_of(highlighted_lines) { |highlight, current_line, str|
+        class_name = highlight ? "highlight" : ""
+        sprintf '<span class="%s">%5d</span>', class_name, current_line
       }
     end
 
     def formatted_code
-      %{<div class="code">#{super}</div>}
+      %{<div class="code_linenums">#{formatted_nums.join}</div><div class="code">#{super}</div>}
     end
   end
 end

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -41,6 +41,14 @@
         background: #f0f0f5;
     }
 
+    .clearfix::after{
+        clear: both;
+        content: ".";
+        display: block;
+        height: 0;
+        visibility: hidden;
+    }
+
     /* ---------------------------------------------------------------------
      * Basic layout
      * --------------------------------------------------------------------- */
@@ -379,7 +387,7 @@
      * Monospace
      * --------------------------------------------------------------------- */
 
-    pre, code, .repl input, .repl .prompt span, textarea {
+    pre, code, .repl input, .repl .prompt span, textarea, .code_linenums {
         font-family: menlo, lucida console, monospace;
         font-size: 8pt;
     }
@@ -394,6 +402,11 @@
         border-radius: 3px;
         margin-bottom: 2px;
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.03), 1px 1px 0 rgba(0, 0, 0, 0.05), -1px 1px 0 rgba(0, 0, 0, 0.05), 0 0 0 4px rgba(0, 0, 0, 0.04);
+    }
+
+    .code_block{
+        background: #f1f1f1;
+        border-left: 1px solid #ccc;
     }
 
     /* Titlebar */
@@ -447,13 +460,31 @@
         box-shadow: inset 3px 3px 3px rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(0, 0, 0, 0.1);
     }
 
+    .code_linenums{
+        background:#f1f1f1;
+        padding-top:10px;
+        padding-bottom:9px;
+        float:left;
+    }
+    
+    .code_linenums span{
+        display:block;
+        padding:0 12px;
+    }
+
     .code {
         margin-bottom: -1px;
+        border-top-left-radius:2px;
     }
 
     .code {
         padding: 10px 0;
         overflow: auto;
+    }
+
+    .code pre{
+        padding-left:12px;
+        min-height:16px;
     }
 
     /* Source unavailable */
@@ -489,7 +520,7 @@
         100% { background: rgba(220, 30, 30, 0.1); }
     }
 
-    .code .highlight {
+    .code .highlight, .code_linenums .highlight {
         background: rgba(220, 30, 30, 0.1);
         -webkit-animation: highlight 400ms linear 1;
         -moz-animation: highlight 400ms linear 1;

--- a/lib/better_errors/templates/variable_info.erb
+++ b/lib/better_errors/templates/variable_info.erb
@@ -1,10 +1,11 @@
-<header class="trace_info">
+<header class="trace_info clearfix">
     <div class="title">
         <h2 class="name"><%= @frame.name %></h2>
         <div class="location"><span class="filename"><a href="<%= editor_url(@frame) %>"><%= @frame.pretty_path %></a></span></div>
     </div>
-    
-    <%== html_formatted_code_block @frame %>
+    <div class="code_block clearfix">
+        <%== html_formatted_code_block @frame %>
+    </div>
 
     <% if BetterErrors.binding_of_caller_available? && @frame.frame_binding %>
         <div class="repl">


### PR DESCRIPTION
Trying to copy the code would give you a bunch of line numbers that needed to be edited out by hand. The horrors of this experience are now over. A pull request has come to save us. 

Because this pull request is the hero that better_errors deserves, but not the one it needs right now... although it would be helpful to have anyway... And so we'll merge it into master, because it can take it. Because this pull request is not a hero, it's a silent guardian, a watchful protector, a Dark Knight...
