### PR TITLE
Combine duplicate CSS classes

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -475,9 +475,6 @@
     .code {
         margin-bottom: -1px;
         border-top-left-radius:2px;
-    }
-
-    .code {
         padding: 10px 0;
         overflow: auto;
     }


### PR DESCRIPTION
For some reason, there were two .code css definitions. I've combined these into one because there seems to be no actual reason for why these are separate. 

:shipit: 
