### PR TITLE
ENV variable to disable better_errors

### DIFF
--- a/lib/better_errors/rails.rb
+++ b/lib/better_errors/rails.rb
@@ -18,7 +18,7 @@ module BetterErrors
     end
 
     def use_better_errors?
-      !Rails.env.production? and app.config.consider_all_requests_local
+      !Rails.env.production? and app.config.consider_all_requests_local and ENV["DISABLE_BETTER_ERRORS"].nil?
     end
 
     def app


### PR DESCRIPTION
There are some cases when project team is large and somebody doesn't want to use better_errors and prefer vanilla error page from Rails.

With this option it's possible to disable better_errors with ENV variable.
