### PR TITLE
Don't crash when original_exception is nil

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -87,7 +87,7 @@ module BetterErrors
     end
 
     def real_exception(exception)
-      if exception.respond_to? :original_exception
+      if exception.respond_to?(:original_exception) && exception.original_exception.is_a?(Exception)
         exception.original_exception
       else
         exception


### PR DESCRIPTION
Check that exception.orignal_exception is an exception if the exception respond_to? :orignal_exception

[Certain exception types](http://api.rubyonrails.org/classes/ActiveRecord/StatementInvalid.html) respond_to? original_exception, but [the value may not be set](https://github.com/rails/rails/blob/df2226ea16922fd4e2ea72b8ee372a4cb5621114/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L499)
and it would cause an [undefined method message for nil class exception in better_errors](https://github.com/charliesome/better_errors/blob/3be2c834e8a644cfd5436f0b107c70d713f46de6/lib/better_errors/middleware.rb#L118).
