### PR TITLE
Popup full exception message as title even when displayed one is truncated

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -731,7 +731,7 @@
     <div class='top'>
         <header class="exception">
             <h2><strong><%= exception.class %></strong> <span>at <%= request_path %></span></h2>
-            <p><%= exception_message %></p>
+            <p title="<%= exception_message %>"><%= exception_message %></p>
         </header>
     </div>
 

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -19,7 +19,8 @@ module BetterErrors
     }
   
     it "includes the error message" do
-      response.should include("you divided by zero you silly goose!")
+      error_message = "you divided by zero you silly goose!"
+      response.should include("<p title=\"#{error_message}\">#{error_message}</p>")
     end
   
     it "includes the request path" do


### PR DESCRIPTION
In an error page, an exception message is truncated when it's too long, but it is useful to see full it. For it I use "title" attribute in `<p>` tag. I also revise existing spec.
Please advise if this approach doesn't match your taste.
