### PR TITLE
move the cursor to the end of the input when navigating through commands...

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -770,6 +770,7 @@
     var OID = <%== object_id.to_s.inspect %>;
     
     var previousFrame = null;
+    var set_cursor_timer = 0;
     var previousFrameInfo = null;
     var allFrames = document.querySelectorAll("ul.frames li");
     var allFrameInfos = document.querySelectorAll(".frame_info");
@@ -821,6 +822,11 @@
         
         REPL.all[this.index] = this;
     }
+
+    REPL.prototype.set_cursor = function() {
+        this.inputElement.value = this.inputElement.value;
+        clearInterval(set_cursor_timer);
+    }
     
     REPL.prototype.focus = function() {
         this.inputElement.focus();
@@ -837,11 +843,7 @@
     
     REPL.prototype.setInput = function(text) {
         this.inputElement.value = text;
-        
-        if(this.inputElement.setSelectionRange) {
-            // set cursor to end of input
-            this.inputElement.setSelectionRange(text.length, text.length);
-        }
+        this.inputElement.value = this.inputElement.value;
     };
     
     REPL.prototype.writeRawOutput = function(output) {
@@ -906,6 +908,9 @@
         } else if(ev.keyCode == 38 || (ev.ctrlKey && ev.keyCode == 80)) {
             // the user pressed the up arrow or Ctrl-P
             this.onNavigateHistory(-1);
+            self = this
+            set_cursor_timer = setInterval(function(){self.set_cursor()}, 1);
+
             return false;
         } else if(ev.keyCode == 40 || (ev.ctrlKey && ev.keyCode == 78)) {
             // the user pressed the down arrow or Ctrl-N


### PR DESCRIPTION
I fixed that unusual behavior when the user navigates through the history of previously executed commands. If user use  the arrow up key then  the cursor always jumps to the beginning of the input. 
I found a line  of code that was trying to fix that but it didn't work so I spend some time trying to figure out why. The reason was the default browser behavior that you can't prevent  by simply returning from the onkeydown function. 
Even though, my patch looks like a dirty hack, that's the only solution I found to make it work. Basically if you press arrow up in the text field,  after all the code related to KeyDown event will be ran, the browser will move the cursor at the beginning of the string. So, the only solution I could apply is to wait a millisecond and move that cursor back to the end where it belongs. 
