### PR TITLE
Update README to include reminder about config.consider_all_requests_local

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ gem "binding_of_caller"
 
 This is an optional dependency however, and Better Errors will work without it.
 
+_Note: If you discover that Better Errors isn't working - particularly after upgrading from version 0.5.0 or less - be sure to set `config.consider_all_requests_local = true` in `config/environments/development.rb`._
+
 ## Security
 
 **NOTE:** It is *critical* you put better\_errors in the **development** section. **Do NOT run better_errors in production, or on Internet facing hosts.**


### PR DESCRIPTION
**Problem:**
- I took forever to upgrade `better_errors` because the last time I tried it broke, I freaked out, and didn't dig into why. Ashamed that I was using such an old version, I dug into where things stopped working for me and realized [this commit](https://github.com/charliesome/better_errors/commit/7d978a220af774fb4967bc5c13d1998987188525) introduced a check to verify that `config.consider_all_requests_local = true` in `development.rb`. So I scampered into that file, made the change, and verified the fix. So I wanted to include a note in the README about it for others.
