### PR TITLE
Readme: Debug AJAX requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ get "/" do
 end
 ```
 
+### Debug AJAX requests
+
+Visit `/__better_errors` on your app's root path to view the error page for the last exception that occurred, even when it has been triggered by an AJAX request.
+
 ### Unicorn, Puma, and other multi-worker servers
 
 Better Errors works by leaving a lot of context in server process memory. If


### PR DESCRIPTION
Thanks @charliesome for this awesome gem!

This PR adds a short hint explaining that there is the `/__better_errors` path to show up an exception page for the previous error, especially useful when it happened in an AJAX request.
