### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/spec/better_errors/code_formatter_spec.rb
+++ b/spec/better_errors/code_formatter_spec.rb
@@ -7,13 +7,13 @@ module BetterErrors
     let(:formatter) { CodeFormatter.new(filename, 8) }
     
     it "picks an appropriate scanner" do
-      formatter.coderay_scanner.should == :ruby
+      expect(formatter.coderay_scanner).to eq(:ruby)
     end
     
     it "shows 5 lines of context" do
-      formatter.line_range.should == (3..13)
+      expect(formatter.line_range).to eq(3..13)
       
-      formatter.context_lines.should == [
+      expect(formatter.context_lines).to eq([
           "three\n",
           "four\n",
           "five\n",
@@ -25,40 +25,40 @@ module BetterErrors
           "eleven\n",
           "twelve\n",
           "thirteen\n"
-        ]
+        ])
     end
 
     it "works when the line is right on the edge" do
       formatter = CodeFormatter.new(filename, 20)
-      formatter.line_range.should == (15..20)
+      expect(formatter.line_range).to eq(15..20)
     end
 
     describe CodeFormatter::HTML do
       it "highlights the erroring line" do
         formatter = CodeFormatter::HTML.new(filename, 8)
-        formatter.output.should =~ /highlight.*eight/
+        expect(formatter.output).to match(/highlight.*eight/)
       end
 
       it "works when the line is right on the edge" do
         formatter = CodeFormatter::HTML.new(filename, 20)
-        formatter.output.should_not == formatter.source_unavailable
+        expect(formatter.output).not_to eq(formatter.source_unavailable)
       end
       
       it "doesn't barf when the lines don't make any sense" do
         formatter = CodeFormatter::HTML.new(filename, 999)
-        formatter.output.should == formatter.source_unavailable
+        expect(formatter.output).to eq(formatter.source_unavailable)
       end
       
       it "doesn't barf when the file doesn't exist" do
         formatter = CodeFormatter::HTML.new("fkdguhskd7e l", 1)
-        formatter.output.should == formatter.source_unavailable
+        expect(formatter.output).to eq(formatter.source_unavailable)
       end
     end
 
     describe CodeFormatter::Text do
       it "highlights the erroring line" do
         formatter = CodeFormatter::Text.new(filename, 8)
-        formatter.output.should == <<-TEXT.gsub(/^        /, "")
+        expect(formatter.output).to eq <<-TEXT.gsub(/^        /, "")
             3   three
             4   four
             5   five
@@ -75,17 +75,17 @@ module BetterErrors
 
       it "works when the line is right on the edge" do
         formatter = CodeFormatter::Text.new(filename, 20)
-        formatter.output.should_not == formatter.source_unavailable
+        expect(formatter.output).not_to eq(formatter.source_unavailable)
       end
 
       it "doesn't barf when the lines don't make any sense" do
         formatter = CodeFormatter::Text.new(filename, 999)
-        formatter.output.should == formatter.source_unavailable
+        expect(formatter.output).to eq(formatter.source_unavailable)
       end
       
       it "doesn't barf when the file doesn't exist" do
         formatter = CodeFormatter::Text.new("fkdguhskd7e l", 1)
-        formatter.output.should == formatter.source_unavailable
+        expect(formatter.output).to eq(formatter.source_unavailable)
       end
     end
   end

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -19,15 +19,15 @@ module BetterErrors
     }
   
     it "includes the error message" do
-      response.should include("you divided by zero you silly goose!")
+      expect(response).to include("you divided by zero you silly goose!")
     end
   
     it "includes the request path" do
-      response.should include("/some/path")
+      expect(response).to include("/some/path")
     end
   
     it "includes the exception class" do
-      response.should include("ZeroDivisionError")
+      expect(response).to include("ZeroDivisionError")
     end
     
     context "variable inspection" do
@@ -36,41 +36,41 @@ module BetterErrors
       if BetterErrors.binding_of_caller_available?
         it "shows local variables" do
           html = error_page.do_variables("index" => 0)[:html]
-          html.should include("local_a")
-          html.should include(":value_for_local_a")
-          html.should include("local_b")
-          html.should include(":value_for_local_b")
+          expect(html).to include("local_a")
+          expect(html).to include(":value_for_local_a")
+          expect(html).to include("local_b")
+          expect(html).to include(":value_for_local_b")
         end
       else
         it "tells the user to add binding_of_caller to their gemfile to get fancy features" do
           html = error_page.do_variables("index" => 0)[:html]
-          html.should include(%{gem "binding_of_caller"})
+          expect(html).to include(%{gem "binding_of_caller"})
         end
       end
       
       it "shows instance variables" do
         html = error_page.do_variables("index" => 0)[:html]
-        html.should include("inst_c")
-        html.should include(":value_for_inst_c")
-        html.should include("inst_d")
-        html.should include(":value_for_inst_d")
+        expect(html).to include("inst_c")
+        expect(html).to include(":value_for_inst_c")
+        expect(html).to include("inst_d")
+        expect(html).to include(":value_for_inst_d")
       end
 
       it "shows filter instance variables" do
-        BetterErrors.stub(:ignored_instance_variables).and_return([ :@inst_d ])
+        allow(BetterErrors).to receive(:ignored_instance_variables).and_return([ :@inst_d ])
         html = error_page.do_variables("index" => 0)[:html]
-        html.should include("inst_c")
-        html.should include(":value_for_inst_c")
-        html.should_not include('<td class="name">@inst_d</td>')
-        html.should_not include("<pre>:value_for_inst_d</pre>")
+        expect(html).to include("inst_c")
+        expect(html).to include(":value_for_inst_c")
+        expect(html).not_to include('<td class="name">@inst_d</td>')
+        expect(html).not_to include("<pre>:value_for_inst_d</pre>")
       end
     end
     
     it "doesn't die if the source file is not a real filename" do
-      exception.stub(:backtrace).and_return([
+      allow(exception).to receive(:backtrace).and_return([
         "<internal:prelude>:10:in `spawn_rack_application'"
       ])
-      response.should include("Source unavailable")
+      expect(response).to include("Source unavailable")
     end
   end
 end

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -6,37 +6,37 @@ module BetterErrors
     let(:exception) { RuntimeError.new("oh no :(") }
 
     it "passes non-error responses through" do
-      app.call({}).should == ":)"
+      expect(app.call({})).to eq(":)")
     end
 
     it "calls the internal methods" do
-      app.should_receive :internal_call
+      expect(app).to receive :internal_call
       app.call("PATH_INFO" => "/__better_errors/1/preform_awesomness")
     end
 
     it "calls the internal methods on any subfolder path" do
-      app.should_receive :internal_call
+      expect(app).to receive :internal_call
       app.call("PATH_INFO" => "/any_sub/folder/path/__better_errors/1/preform_awesomness")
     end
 
     it "shows the error page" do
-      app.should_receive :show_error_page
+      expect(app).to receive :show_error_page
       app.call("PATH_INFO" => "/__better_errors/")
     end
 
     it "shows the error page on any subfolder path" do
-      app.should_receive :show_error_page
+      expect(app).to receive :show_error_page
       app.call("PATH_INFO" => "/any_sub/folder/path/__better_errors/")
     end
 
     it "doesn't show the error page to a non-local address" do
-      app.should_not_receive :better_errors_call
+      expect(app).not_to receive :better_errors_call
       app.call("REMOTE_ADDR" => "1.2.3.4")
     end
 
     it "shows to a whitelisted IP" do
       BetterErrors::Middleware.allow_ip! '77.55.33.11'
-      app.should_receive :better_errors_call
+      expect(app).to receive :better_errors_call
       app.call("REMOTE_ADDR" => "77.55.33.11")
     end
 
@@ -53,12 +53,12 @@ module BetterErrors
 
       it "shows that no errors have been recorded" do
         status, headers, body = app.call("PATH_INFO" => "/__better_errors")
-        body.join.should match /No errors have been recorded yet./
+        expect(body.join).to match /No errors have been recorded yet./
       end
 
       it "shows that no errors have been recorded on any subfolder path" do
         status, headers, body = app.call("PATH_INFO" => "/any_sub/folder/path/__better_errors")
-        body.join.should match /No errors have been recorded yet./
+        expect(body.join).to match /No errors have been recorded yet./
       end
     end
 
@@ -68,7 +68,7 @@ module BetterErrors
       it "returns status 500" do
         status, headers, body = app.call({})
 
-        status.should == 500
+        expect(status).to eq(500)
       end
 
       context "original_exception" do
@@ -88,9 +88,9 @@ module BetterErrors
 
           status, _, body = app.call({})
 
-          status.should == 500
-          body.join.should_not match(/Other Exception/)
-          body.join.should match(/Original Exception/)
+          expect(status).to eq(500)
+          expect(body.join).not_to match(/Other Exception/)
+          expect(body.join).to match(/Original Exception/)
         end
 
         it "won't crash if the exception responds_to but doesn't have an original_exception" do
@@ -100,44 +100,44 @@ module BetterErrors
 
           status, _, body = app.call({})
 
-          status.should == 500
-          body.join.should match(/Other Exception/)
+          expect(status).to eq(500)
+          expect(body.join).to match(/Other Exception/)
         end
       end
 
       it "returns ExceptionWrapper's status_code" do
         ad_ew = double("ActionDispatch::ExceptionWrapper")
-        ad_ew.stub('new').with({}, exception ){ double("ExceptionWrapper", status_code: 404) }
+        allow(ad_ew).to receive('new').with({}, exception ){ double("ExceptionWrapper", status_code: 404) }
         stub_const('ActionDispatch::ExceptionWrapper', ad_ew)
 
         status, headers, body = app.call({})
 
-        status.should == 404
+        expect(status).to eq(404)
       end
 
       it "returns UTF-8 error pages" do
         status, headers, body = app.call({})
 
-        headers["Content-Type"].should match /charset=utf-8/
+        expect(headers["Content-Type"]).to match /charset=utf-8/
       end
 
       it "returns text pages by default" do
         status, headers, body = app.call({})
 
-        headers["Content-Type"].should match /text\/plain/
+        expect(headers["Content-Type"]).to match /text\/plain/
       end
 
       it "returns HTML pages by default" do
         # Chrome's 'Accept' header looks similar this.
         status, headers, body = app.call("HTTP_ACCEPT" => "text/html,application/xhtml+xml;q=0.9,*/*")
 
-        headers["Content-Type"].should match /text\/html/
+        expect(headers["Content-Type"]).to match /text\/html/
       end
 
       it "logs the exception" do
         logger = Object.new
-        logger.should_receive :fatal
-        BetterErrors.stub(:logger).and_return(logger)
+        expect(logger).to receive :fatal
+        allow(BetterErrors).to receive(:logger).and_return(logger)
 
         app.call({})
       end

--- a/spec/better_errors/raised_exception_spec.rb
+++ b/spec/better_errors/raised_exception_spec.rb
@@ -5,27 +5,52 @@ module BetterErrors
     let(:exception) { RuntimeError.new("whoops") }
     subject { RaisedException.new(exception) }
 
-    its(:exception) { should == exception }
-    its(:message)   { should == "whoops" }
-    its(:type)      { should == RuntimeError }
+    describe '#exception' do
+      subject { super().exception }
+      it { should == exception }
+    end
+
+    describe '#message' do
+      subject { super().message }
+      it   { should == "whoops" }
+    end
+
+    describe '#type' do
+      subject { super().type }
+      it      { should == RuntimeError }
+    end
 
     context "when the exception wraps another exception" do
       let(:original_exception) { RuntimeError.new("something went wrong!") }
       let(:exception) { double(:original_exception => original_exception) }
 
-      its(:exception) { should == original_exception }
-      its(:message)   { should == "something went wrong!" }
+      describe '#exception' do
+        subject { super().exception }
+        it { should == original_exception }
+      end
+
+      describe '#message' do
+        subject { super().message }
+        it   { should == "something went wrong!" }
+      end
     end
 
     context "when the exception is a syntax error" do
       let(:exception) { SyntaxError.new("foo.rb:123: you made a typo!") }
 
-      its(:message) { should == "you made a typo!" }
-      its(:type)    { should == SyntaxError }
+      describe '#message' do
+        subject { super().message }
+        it { should == "you made a typo!" }
+      end
+
+      describe '#type' do
+        subject { super().type }
+        it    { should == SyntaxError }
+      end
 
       it "has the right filename and line number in the backtrace" do
-        subject.backtrace.first.filename.should == "foo.rb"
-        subject.backtrace.first.line.should == 123
+        expect(subject.backtrace.first.filename).to eq("foo.rb")
+        expect(subject.backtrace.first.line).to eq(123)
       end
     end
 
@@ -40,12 +65,19 @@ module BetterErrors
         end
       }
 
-      its(:message) { should == "you made a typo!" }
-      its(:type)    { should == Haml::SyntaxError }
+      describe '#message' do
+        subject { super().message }
+        it { should == "you made a typo!" }
+      end
+
+      describe '#type' do
+        subject { super().type }
+        it    { should == Haml::SyntaxError }
+      end
 
       it "has the right filename and line number in the backtrace" do
-        subject.backtrace.first.filename.should == "foo.rb"
-        subject.backtrace.first.line.should == 123
+        expect(subject.backtrace.first.filename).to eq("foo.rb")
+        expect(subject.backtrace.first.line).to eq(123)
       end
     end
   end

--- a/spec/better_errors/repl/pry_spec.rb
+++ b/spec/better_errors/repl/pry_spec.rb
@@ -15,23 +15,23 @@ module BetterErrors
 
       it "does line continuation" do
         output, prompt, filled = repl.send_input ""
-        output.should == "=> nil\n"
-        prompt.should == ">>"
-        filled.should == ""
+        expect(output).to eq("=> nil\n")
+        expect(prompt).to eq(">>")
+        expect(filled).to eq("")
 
         output, prompt, filled = repl.send_input "def f(x)"
-        output.should == ""
-        prompt.should == ".."
-        filled.should == "  "
+        expect(output).to eq("")
+        expect(prompt).to eq("..")
+        expect(filled).to eq("  ")
 
         output, prompt, filled = repl.send_input "end"
         if RUBY_VERSION >= "2.1.0"
-          output.should == "=> :f\n"
+          expect(output).to eq("=> :f\n")
         else
-          output.should == "=> nil\n"
+          expect(output).to eq("=> nil\n")
         end
-        prompt.should == ">>"
-        filled.should == ""
+        expect(prompt).to eq(">>")
+        expect(filled).to eq("")
       end
 
       it_behaves_like "a REPL provider"

--- a/spec/better_errors/repl/shared_examples.rb
+++ b/spec/better_errors/repl/shared_examples.rb
@@ -1,18 +1,18 @@
 shared_examples_for "a REPL provider" do
   it "evaluates ruby code in a given context" do
     repl.send_input("local_a = 456")
-    fresh_binding.eval("local_a").should == 456
+    expect(fresh_binding.eval("local_a")).to eq(456)
   end
   
   it "returns a tuple of output and the new prompt" do
     output, prompt = repl.send_input("1 + 2")
-    output.should == "=> 3\n"
-    prompt.should == ">>"
+    expect(output).to eq("=> 3\n")
+    expect(prompt).to eq(">>")
   end
   
   it "doesn't barf if the code throws an exception" do
     output, prompt = repl.send_input("raise Exception")
-    output.should include "Exception: Exception"
-    prompt.should == ">>"
+    expect(output).to include "Exception: Exception"
+    expect(prompt).to eq(">>")
   end
 end

--- a/spec/better_errors/stack_frame_spec.rb
+++ b/spec/better_errors/stack_frame_spec.rb
@@ -4,80 +4,80 @@ module BetterErrors
   describe StackFrame do
     context "#application?" do
       it "is true for application filenames" do
-        BetterErrors.stub(:application_root).and_return("/abc/xyz")
+        allow(BetterErrors).to receive(:application_root).and_return("/abc/xyz")
         frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index")
 
-        frame.application?.should be_true
+        expect(frame.application?).to be_true
       end
 
       it "is false for everything else" do
-        BetterErrors.stub(:application_root).and_return("/abc/xyz")
+        allow(BetterErrors).to receive(:application_root).and_return("/abc/xyz")
         frame = StackFrame.new("/abc/nope", 123, "foo")
 
-        frame.application?.should be_false
+        expect(frame.application?).to be_false
       end
 
       it "doesn't care if no application_root is set" do
         frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index")
 
-        frame.application?.should be_false
+        expect(frame.application?).to be_false
       end
     end
 
     context "#gem?" do
       it "is true for gem filenames" do
-        Gem.stub(:path).and_return(["/abc/xyz"])
+        allow(Gem).to receive(:path).and_return(["/abc/xyz"])
         frame = StackFrame.new("/abc/xyz/gems/whatever-1.2.3/lib/whatever.rb", 123, "foo")
 
-        frame.gem?.should be_true
+        expect(frame.gem?).to be_true
       end
 
       it "is false for everything else" do
-        Gem.stub(:path).and_return(["/abc/xyz"])
+        allow(Gem).to receive(:path).and_return(["/abc/xyz"])
         frame = StackFrame.new("/abc/nope", 123, "foo")
 
-        frame.gem?.should be_false
+        expect(frame.gem?).to be_false
       end
     end
 
     context "#application_path" do
       it "chops off the application root" do
-        BetterErrors.stub(:application_root).and_return("/abc/xyz")
+        allow(BetterErrors).to receive(:application_root).and_return("/abc/xyz")
         frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index")
 
-        frame.application_path.should == "app/controllers/crap_controller.rb"
+        expect(frame.application_path).to eq("app/controllers/crap_controller.rb")
       end
     end
 
     context "#gem_path" do
       it "chops of the gem path and stick (gem) there" do
-        Gem.stub(:path).and_return(["/abc/xyz"])
+        allow(Gem).to receive(:path).and_return(["/abc/xyz"])
         frame = StackFrame.new("/abc/xyz/gems/whatever-1.2.3/lib/whatever.rb", 123, "foo")
 
-        frame.gem_path.should == "whatever (1.2.3) lib/whatever.rb"
+        expect(frame.gem_path).to eq("whatever (1.2.3) lib/whatever.rb")
       end
 
       it "prioritizes gem path over application path" do
-        BetterErrors.stub(:application_root).and_return("/abc/xyz")
-        Gem.stub(:path).and_return(["/abc/xyz/vendor"])
+        allow(BetterErrors).to receive(:application_root).and_return("/abc/xyz")
+        allow(Gem).to receive(:path).and_return(["/abc/xyz/vendor"])
         frame = StackFrame.new("/abc/xyz/vendor/gems/whatever-1.2.3/lib/whatever.rb", 123, "foo")
 
-        frame.gem_path.should == "whatever (1.2.3) lib/whatever.rb"
+        expect(frame.gem_path).to eq("whatever (1.2.3) lib/whatever.rb")
       end
     end
 
     context "#pretty_path" do
       it "returns #application_path for application paths" do
-        BetterErrors.stub(:application_root).and_return("/abc/xyz")
+        allow(BetterErrors).to receive(:application_root).and_return("/abc/xyz")
         frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index")
-        frame.pretty_path.should == frame.application_path
+        expect(frame.pretty_path).to eq(frame.application_path)
       end
 
       it "returns #gem_path for gem paths" do
-        Gem.stub(:path).and_return(["/abc/xyz"])
+        allow(Gem).to receive(:path).and_return(["/abc/xyz"])
         frame = StackFrame.new("/abc/xyz/gems/whatever-1.2.3/lib/whatever.rb", 123, "foo")
 
-        frame.pretty_path.should == frame.gem_path
+        expect(frame.pretty_path).to eq(frame.gem_path)
       end
     end
 
@@ -87,36 +87,36 @@ module BetterErrors
       rescue SyntaxError => syntax_error
       end
       frames = StackFrame.from_exception(syntax_error)
-      frames.first.filename.should == "my_file.rb"
-      frames.first.line.should == 123
+      expect(frames.first.filename).to eq("my_file.rb")
+      expect(frames.first.line).to eq(123)
     end
 
     it "doesn't blow up if no method name is given" do
       error = StandardError.allocate
 
-      error.stub(:backtrace).and_return(["foo.rb:123"])
+      allow(error).to receive(:backtrace).and_return(["foo.rb:123"])
       frames = StackFrame.from_exception(error)
-      frames.first.filename.should == "foo.rb"
-      frames.first.line.should == 123
+      expect(frames.first.filename).to eq("foo.rb")
+      expect(frames.first.line).to eq(123)
 
-      error.stub(:backtrace).and_return(["foo.rb:123: this is an error message"])
+      allow(error).to receive(:backtrace).and_return(["foo.rb:123: this is an error message"])
       frames = StackFrame.from_exception(error)
-      frames.first.filename.should == "foo.rb"
-      frames.first.line.should == 123
+      expect(frames.first.filename).to eq("foo.rb")
+      expect(frames.first.line).to eq(123)
     end
 
     it "ignores a backtrace line if its format doesn't make any sense at all" do
       error = StandardError.allocate
-      error.stub(:backtrace).and_return(["foo.rb:123:in `foo'", "C:in `find'", "bar.rb:123:in `bar'"])
+      allow(error).to receive(:backtrace).and_return(["foo.rb:123:in `foo'", "C:in `find'", "bar.rb:123:in `bar'"])
       frames = StackFrame.from_exception(error)
-      frames.count.should == 2
+      expect(frames.count).to eq(2)
     end
 
     it "doesn't blow up if a filename contains a colon" do
       error = StandardError.allocate
-      error.stub(:backtrace).and_return(["crap:filename.rb:123"])
+      allow(error).to receive(:backtrace).and_return(["crap:filename.rb:123"])
       frames = StackFrame.from_exception(error)
-      frames.first.filename.should == "crap:filename.rb"
+      expect(frames.first.filename).to eq("crap:filename.rb")
     end
 
     it "doesn't blow up with a BasicObject as frame binding" do
@@ -125,7 +125,7 @@ module BetterErrors
         ::Kernel.binding
       end
       frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index", obj.my_binding)
-      frame.class_name.should == 'BasicObject'
+      expect(frame.class_name).to eq('BasicObject')
     end
 
     it "sets method names properly" do
@@ -140,11 +140,11 @@ module BetterErrors
 
       frame = StackFrame.from_exception(obj.my_method).first
       if BetterErrors.binding_of_caller_available?
-        frame.method_name.should == "#my_method"
-        frame.class_name.should == "String"
+        expect(frame.method_name).to eq("#my_method")
+        expect(frame.class_name).to eq("String")
       else
-        frame.method_name.should == "my_method"
-        frame.class_name.should == nil
+        expect(frame.method_name).to eq("my_method")
+        expect(frame.class_name).to eq(nil)
       end
     end
 

--- a/spec/better_errors_spec.rb
+++ b/spec/better_errors_spec.rb
@@ -3,38 +3,38 @@ require "spec_helper"
 describe BetterErrors do
   context ".editor" do
     it "defaults to textmate" do
-      subject.editor["foo.rb", 123].should == "txmt://open?url=file://foo.rb&line=123"
+      expect(subject.editor["foo.rb", 123]).to eq("txmt://open?url=file://foo.rb&line=123")
     end
 
     it "url escapes the filename" do
-      subject.editor["&.rb", 0].should == "txmt://open?url=file://%26.rb&line=0"
+      expect(subject.editor["&.rb", 0]).to eq("txmt://open?url=file://%26.rb&line=0")
     end
 
     [:emacs, :emacsclient].each do |editor|
       it "uses emacs:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "emacs://"
+        expect(subject.editor[]).to start_with "emacs://"
       end
     end
 
     [:macvim, :mvim].each do |editor|
       it "uses mvim:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "mvim://"
+        expect(subject.editor[]).to start_with "mvim://"
       end
     end
 
     [:sublime, :subl, :st].each do |editor|
       it "uses subl:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "subl://"
+        expect(subject.editor[]).to start_with "subl://"
       end
     end
 
     [:textmate, :txmt, :tm].each do |editor|
       it "uses txmt:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "txmt://"
+        expect(subject.editor[]).to start_with "txmt://"
       end
     end
 
@@ -42,7 +42,7 @@ describe BetterErrors do
       it "uses emacs:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "emacs://"
+        expect(subject.editor[]).to start_with "emacs://"
       end
     end
 
@@ -50,7 +50,7 @@ describe BetterErrors do
       it "uses mvim:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "mvim://"
+        expect(subject.editor[]).to start_with "mvim://"
       end
     end
 
@@ -58,7 +58,7 @@ describe BetterErrors do
       it "uses mvim:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "subl://"
+        expect(subject.editor[]).to start_with "subl://"
       end
     end
 
@@ -66,7 +66,7 @@ describe BetterErrors do
       it "uses txmt:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "txmt://"
+        expect(subject.editor[]).to start_with "txmt://"
       end
     end
   end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 89 conversions
  from: obj.should
    to: expect(obj).to
- 54 conversions
  from: == expected
    to: eq(expected)
- 18 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 9 conversions
  from: its(:attr) { }
    to: describe '#attr' do subject { super().attr }; it { } end
- 6 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 5 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 1 conversion
  from: =~ /pattern/
    to: match(/pattern/)
- 1 conversion
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
