### PR TITLE
application trace should be at Application frames when Gem.path is empty

### DIFF
--- a/lib/better_errors/stack_frame.rb
+++ b/lib/better_errors/stack_frame.rb
@@ -49,10 +49,10 @@ module BetterErrors
     end
 
     def context
-      if gem?
-        :gem
-      elsif application?
+      if application?
         :application
+      elsif gem?
+        :gem
       else
         :dunno
       end

--- a/spec/better_errors/stack_frame_spec.rb
+++ b/spec/better_errors/stack_frame_spec.rb
@@ -2,6 +2,16 @@ require "spec_helper"
 
 module BetterErrors
   describe StackFrame do
+    context "#context" do
+      it 'is :application if Gem.path is empty' do
+        Gem.stub(:path).and_return([''])
+        BetterErrors.stub(:application_root).and_return("/abc/xyz")
+        frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "foo")
+
+        frame.context.should == :application
+      end
+    end
+
     context "#application?" do
       it "is true for application filenames" do
         BetterErrors.stub(:application_root).and_return("/abc/xyz")


### PR DESCRIPTION
fix https://github.com/charliesome/better_errors/issues/252
