### PR TITLE
Fixes compatibility with pry 0.10.x

### DIFF
--- a/lib/better_errors/repl/pry.rb
+++ b/lib/better_errors/repl/pry.rb
@@ -36,8 +36,8 @@ module BetterErrors
         @fiber = Fiber.new do
           @pry.repl binding
         end
-        @input = REPL::Pry::Input.new
-        @output = REPL::Pry::Output.new
+        @input = BetterErrors::REPL::Pry::Input.new
+        @output = BetterErrors::REPL::Pry::Output.new
         @pry = ::Pry.new input: @input, output: @output
         @pry.hooks.clear_all if defined?(@pry.hooks.clear_all)
         @fiber.resume


### PR DESCRIPTION
Pry 0.10.x introduced Pry::Output class, due to class loading it conflicts with BetterErrors::REPL::Pry::Output, so let’s be more explicit about which class we use.

This fixes #255.
