### PR TITLE
Fix crash if binding is nil, closes #261

### DIFF
--- a/lib/better_errors/exception_extension.rb
+++ b/lib/better_errors/exception_extension.rb
@@ -4,7 +4,7 @@ module BetterErrors
 
     def set_backtrace(*)
       if caller_locations.none? { |loc| loc.path == __FILE__ }
-        @__better_errors_bindings_stack = binding.callers.drop(1)
+        @__better_errors_bindings_stack = ::Kernel.binding.callers.drop(1)
       end
 
       super


### PR DESCRIPTION
I looked and it seemed like this was the only place needed to make this change, but if I am mistaken let me know.
