### PR TITLE
Fix issue when rails can't determine IP address

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -65,7 +65,7 @@ module BetterErrors
     def allow_ip?(env)
       request = Rack::Request.new(env)
       return true unless request.ip and !request.ip.strip.empty?
-      ip = IPAddr.new request.ip.split("%").first
+      ip = IPAddr.new request.ip.split("%").first rescue "127.0.0.1"
       ALLOWED_IPS.any? { |subnet| subnet.include? ip }
     end
 


### PR DESCRIPTION
Websockets during local development are sending empty remote_address so rails see: Started POST "/end_point" for undefined
