### PR TITLE
Fix history retrieval in the console

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -875,6 +875,7 @@
             this.previousCommandOffset = previousCommands.push(text);
             if(previousCommands.length > 100) {
               previousCommands.splice(0, 1);
+              this.previousCommandOffset -= 1;
             }
             localStorage.setItem("better_errors_previous_commands", JSON.stringify(previousCommands));
         }


### PR DESCRIPTION
This fixes #282 "Need to press <up> twice in the console". Full info in issue.

When we reach the max history limit we remove an entry from the history array but aren't updating our history pointer (`previousCommandOffset`) to match.
