### PR TITLE
add exception hints

### DIFF
--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -68,14 +68,16 @@ module BetterErrors
       case exception
       when NoMethodError
         matches = /\Aundefined method `([^']+)' for ([^:]+):(\w+)\z/.match(message)
-        method = matches[1]
-        val = matches[2]
-        klass = matches[3]
+        if matches
+          method = matches[1]
+          val = matches[2]
+          klass = matches[3]
 
-        if val == "nil"
-          @hint = "Something is `nil` when it probably shouldn't be."
-        else
-          @hint = "`#{method}` is being called on a `#{klass}`, which probably isn't the type you were expecting."
+          if val == "nil"
+            @hint = "Something is `nil` when it probably shouldn't be."
+          else
+            @hint = "`#{method}` is being called on a `#{klass}`, which probably isn't the type you were expecting."
+          end
         end
       when NameError
         matches = /\Aundefined local variable or method `([^']+)' for/.match(message)

--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -65,7 +65,8 @@ module BetterErrors
     end
 
     def setup_hint
-      if exception.is_a?(NoMethodError)
+      case exception
+      when NoMethodError
         matches = /\Aundefined method `([^']+)' for ([^:]+):(\w+)\z/.match(message)
         method = matches[1]
         val = matches[2]
@@ -75,6 +76,12 @@ module BetterErrors
           @hint = "Something is `nil` when it probably shouldn't be."
         else
           @hint = "`#{method}` is being called on a `#{klass}`, which probably isn't the type you were expecting."
+        end
+      when NameError
+        matches = /\Aundefined local variable or method `([^']+)' for/.match(message)
+        if matches
+          method_or_var = matches[1]
+          @hint = "`#{method_or_var}` is probably misspelled."
         end
       end
     end

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -90,7 +90,7 @@
         nav.sidebar,
         .frame_info {
             position: fixed;
-            top: 95px;
+            top: 102px;
             bottom: 0;
 
             box-sizing: border-box;
@@ -102,7 +102,7 @@
         nav.sidebar {
             width: 40%;
             left: 20px;
-            top: 115px;
+            top: 122px;
             bottom: 20px;
         }
 
@@ -131,7 +131,7 @@
     header.exception {
         padding: 18px 20px;
 
-        height: 59px;
+        height: 66px;
         min-height: 59px;
 
         overflow: hidden;
@@ -733,6 +733,9 @@
         <header class="exception">
             <h2><strong><%= exception.type %></strong> <span>at <%= request_path %></span></h2>
             <p><%= exception.message %></p>
+            <% if exception.hint %>
+              <h2>Hint: <%= exception.hint %></h2>
+            <% end %>
         </header>
     </div>
 

--- a/spec/better_errors/raised_exception_spec.rb
+++ b/spec/better_errors/raised_exception_spec.rb
@@ -69,6 +69,19 @@ module BetterErrors
       end
     end
 
+    context "when the exception is a NameError" do
+      let(:exception) {
+        begin
+          foo
+        rescue NameError => e
+          e
+        end
+      }
+
+      its(:type) { should == NameError }
+      its(:hint) { should == "`foo` is probably misspelled." }
+    end
+
     context "when the exception is a NoMethodError" do
       let(:exception) {
         begin

--- a/spec/better_errors/raised_exception_spec.rb
+++ b/spec/better_errors/raised_exception_spec.rb
@@ -68,5 +68,29 @@ module BetterErrors
         subject.backtrace.first.line.should == 11
       end
     end
+
+    context "when the exception is a NoMethodError" do
+      let(:exception) {
+        begin
+          val.foo
+        rescue NoMethodError => e
+          e
+        end
+      }
+
+      context "on `nil`" do
+        let(:val) { nil }
+
+        its(:type) { should == NoMethodError }
+        its(:hint) { should == "Something is `nil` when it probably shouldn't be." }
+      end
+
+      context "on other values" do
+        let(:val) { 42 }
+
+        its(:type) { should == NoMethodError }
+        its(:hint) { should == "`foo` is being called on a `Fixnum`, which probably isn't the type you were expecting." }
+      end
+    end
   end
 end


### PR DESCRIPTION
I work with a lot of people who are new to coding, and have found that people often get tripped up with reading Ruby exceptions. For example:

``` ruby
user = User.where(...).first
user # => nil
user.save # NoMethodError: undefined method `save' for nil:NilClass
```

While precise, error messages like this don't do a very good job of guiding the reader to how to fix the problems. This PR is a proof-of-concept giving better_errors users a bit of help.

![screen shot 2015-04-05 at 3 15 34 am](https://cloud.githubusercontent.com/assets/86842/6996139/192e43a2-db43-11e4-9069-4e6a9d0e3773.png)

Feedback welcome! In particular, what edge cases am I missing?

**P.S.** Ideally the message above would read

> Hint: `user` is `nil` when it probably shouldn't be.

but that requires some fancy AST parsing (I think).

**P.P.S.** If others agree it would be useful, I think a good medium-term goal would be to move the backtrace cleaning and hint logic to an external gem, where it could be leveraged by non-web things (like [Exercism](http://exercism.io/)) that can't use better_errors.
