### PR TITLE
Add a quick link to search exception on StackOverflow

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -170,6 +170,12 @@
         color: white;
     }
 
+    header.exception small a {
+        font-weight: 100;
+        font-size: 10pt;
+        color: grey;
+    }
+
     header.exception:hover {
         height: auto;
         z-index: 2;
@@ -733,6 +739,9 @@
         <header class="exception">
             <h2><strong><%= exception.type %></strong> <span>at <%= request_path %></span></h2>
             <p><%= exception.message %></p>
+            <small>
+              <a href="https://stackoverflow.com/search?q=%5Bruby-on-rails%5D+<%= exception.type %>+<%= exception.message %>" target="_blank">Search on Stack Overflow</a>
+            </small>
         </header>
     </div>
 

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -30,6 +30,10 @@ module BetterErrors
       response.should include("ZeroDivisionError")
     end
 
+    it "includes a link to search" do
+      response.should include("https://stackoverflow.com/search?q=%5Bruby-on-rails%5D+ZeroDivisionError")
+    end
+
     context "variable inspection" do
       let(:exception) { empty_binding.eval("raise") rescue $! }
 


### PR DESCRIPTION
> The IEEE have produced a report today where they strongly recommend that from now on, the discipline of Computer Programming should be officially renamed to “Googling Stackoverflow”.

In that spirit...

![screen shot 2015-11-17 at 1 43 58 pm](https://cloud.githubusercontent.com/assets/1568662/11224264/55f22736-8d31-11e5-9df1-f3545a45c6c1.png)
Clicking the link opens a search on StackOverflow for questions about that exception tagged `ruby-on-rails`
