### PR TITLE
Allows expanding the visible lines of code (Fixes #370)

### DIFF
--- a/lib/better_errors/code_formatter/html.rb
+++ b/lib/better_errors/code_formatter/html.rb
@@ -19,8 +19,42 @@ module BetterErrors
       }
     end
 
+    def expander_icon
+      <<-HEREDOC
+<svg aria-hidden="true" class="octicon octicon-unfold"
+     height="16" version="1.1" viewBox="0 0 14 16" width="14">
+  <path fill-rule="evenodd" d="M11.5 7.5L14 10c0 .55-.45 1-1
+    1H9v-1h3.5l-2-2h-7l-2 2H5v1H1c-.55 0-1-.45-1-1l2.5-2.5L0
+    5c0-.55.45-1 1-1h4v1H1.5l2 2h7l2-2H9V4h4c.55 0 1 .45 1
+    1l-2.5 2.5zM6 6h2V3h2L7 0 4 3h2v3zm2 3H6v3H4l3 3 3-3H8V9z">
+  </path>
+</svg>
+      HEREDOC
+    end
+
     def formatted_code
-      %{<div class="code_linenums">#{formatted_nums.join}</div><div class="code">#{super}</div>}
+      code = ''
+
+      unless begin_of_file_reached?
+        code << '<span class="expander">' \
+                  "<a href='#' data-direction='up' title='Expand'>" \
+                    "#{expander_icon}" \
+                  "</a>" \
+                '</span>'
+      end
+
+      code << "<div class='code_linenums'>#{formatted_nums.join}</div>"
+      code << "<div class='code'>#{super}</div>"
+
+      unless end_of_file_reached?
+        code << '<span class="expander">' \
+                  "<a href='#' data-direction='down' title='Expand'>" \
+                    "#{expander_icon}" \
+                  "</a>" \
+                '</span>'
+      end
+
+      code
     end
   end
 end

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -31,8 +31,7 @@ module BetterErrors
     end
 
     def do_variables(opts)
-      index = opts["index"].to_i
-      @frame = backtrace_frames[index]
+      load_frame_from(opts)
       @var_start_time = Time.now.to_f
       { html: render("variable_info") }
     end
@@ -48,6 +47,16 @@ module BetterErrors
       @repls[index] ||= REPL.provider.new(binding, exception)
 
       eval_and_respond(index, code)
+    end
+
+    def do_expand(opts)
+      load_frame_from(opts)
+
+      @frame.upperlines -= 5 if opts['direction'] == 'up'
+      @frame.lowerlines += 5 if opts['direction'] == 'down'
+
+      @var_start_time = Time.now.to_f
+      { html: render("trace_info") }
     end
 
     def backtrace_frames
@@ -92,7 +101,8 @@ module BetterErrors
     end
 
     def html_formatted_code_block(frame)
-      CodeFormatter::HTML.new(frame.filename, frame.line).output
+      CodeFormatter::HTML.new(frame.filename, frame.line, frame.upperlines,
+                              frame.lowerlines).output
     end
 
     def text_formatted_code_block(frame)
@@ -137,6 +147,11 @@ module BetterErrors
         prompt:            prompt,
         result:            result
       }
+    end
+
+    def load_frame_from(opts)
+      index = opts["index"].to_i
+      @frame = backtrace_frames[index]
     end
   end
 end

--- a/lib/better_errors/stack_frame.rb
+++ b/lib/better_errors/stack_frame.rb
@@ -8,12 +8,15 @@ module BetterErrors
     end
 
     attr_reader :filename, :line, :name, :frame_binding
+    attr_accessor :upperlines, :lowerlines
 
-    def initialize(filename, line, name, frame_binding = nil)
+    def initialize(filename, line, name, frame_binding = nil, upperlines = nil, lowerlines = nil)
       @filename       = filename
       @line           = line
       @name           = name
       @frame_binding  = frame_binding
+      @upperlines     = upperlines || line - 5
+      @lowerlines     = lowerlines || line + 5
 
       set_pretty_method_name if frame_binding
     end

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -474,9 +474,21 @@
         float:left;
     }
 
+    .code_block span.expander {
+      display: block;
+      padding: 0 12px;
+      height: 23px;
+    }
+
     .code_linenums span{
         display:block;
         padding:0 12px;
+    }
+
+    .code_block span.expander a {
+      position: relative;
+      top: 3px;
+      margin-bottom: 2px;
     }
 
     .code {
@@ -929,6 +941,33 @@
         if (replInput) replInput.focus();
     }
 
+    function connectExpanders() {
+      var allExpanders = document.querySelectorAll(".expander a");
+      var selectedFrame = document.querySelector("ul.frames li.selected");
+
+      for(var i = 0; i < allExpanders.length; i++) {
+        (function(i, el) {
+          var el = allExpanders[i];
+          el.onclick = function() {
+            var direction = el.getAttribute("data-direction");
+            var index = selectedFrame.getAttribute("data-index");
+            apiCall("expand", { "direction": direction, "index": index }, function(response) {
+                if(response.error) {
+                    el.innerHTML = "<h2 class='error'>" + escapeHTML(response.error) + "</h2>";
+                    if(response.explanation) {
+                      el.innerHTML += "<p class='explanation'>" + escapeHTML(response.explanation) + "</p>";
+                    }
+                    el.innerHTML += "<p><a target='_new' href='https://github.com/charliesome/better_errors'>More about Better Errors</a></p>";
+                } else {
+                  document.querySelector(".code_block").innerHTML = response.html;
+                  connectExpanders();
+                }
+            });
+          }
+        })(i);
+      }
+    }
+
     function selectFrameInfo(index) {
         var el = allFrameInfos[index];
         if(el) {
@@ -946,6 +985,8 @@
                     el.innerHTML += "<p><a target='_new' href='https://github.com/charliesome/better_errors'>More about Better Errors</a></p>";
                 } else {
                     el.innerHTML = response.html;
+
+                    connectExpanders();
 
                     var repl = el.querySelector(".be-repl .be-console");
                     if(repl) {

--- a/lib/better_errors/templates/trace_info.erb
+++ b/lib/better_errors/templates/trace_info.erb
@@ -1,0 +1,1 @@
+<%== html_formatted_code_block @frame %>

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -223,5 +223,34 @@ module BetterErrors
         end
       end
     end
+
+    describe 'do_expand' do
+      context 'requesting more lines of code in the upper direction' do
+        subject(:do_expand) { error_page.do_expand('index' => 0, 'direction' => 'up') }
+        it 'should' do
+          html = do_expand[:html]
+          expect(html).to include("<span class=\"\">    1</span>")
+          expect(html).to include("<span class=\"\">   10</span>")
+          expect(html).to_not include("<span class=\"\">   15</span>")
+        end
+      end
+      context 'requesting one time more lines of code in the lower direction' do
+        it 'should returns the codes from line 1 until line 15' do
+          html = error_page.do_expand('index' => 0, 'direction' => 'down')[:html]
+          expect(html).to include("<span class=\"\">    1</span>")
+          expect(html).to include("<span class=\"\">   15</span>")
+          expect(html).to_not include("<span class=\"\">   16</span>")
+        end
+      end
+      context 'requesting two times more lines of code in the lower direction' do
+        it 'should returns the codes from line 1 until line 20' do
+          error_page.do_expand('index' => 0, 'direction' => 'down')
+          html = error_page.do_expand('index' => 0, 'direction' => 'down')[:html]
+          expect(html).to include("<span class=\"\">    1</span>")
+          expect(html).to include("<span class=\"\">   20</span>")
+          expect(html).to_not include("<span class=\"\">   21</span>")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR implements the "Expand" icons like in Github (see #370). Clicking an expander calls the backend which returns only the code to be updated in the `.code` div so that the reste of the page stays as it is (no reset of the REPL).

Here is a preview:

![screen shot 2017-11-16 at 10 05 18](https://user-images.githubusercontent.com/478564/32882761-b54be898-cab5-11e7-8040-91d93ef0dbec.png)

After having clicked the top expander:

![screen shot 2017-11-16 at 10 05 56](https://user-images.githubusercontent.com/478564/32882808-ceb20e3e-cab5-11e7-968b-bf08cf30554b.png)