### PR TITLE
Fix pry bug that display color escape code

### DIFF
--- a/lib/better_errors/repl/pry.rb
+++ b/lib/better_errors/repl/pry.rb
@@ -43,7 +43,8 @@ module BetterErrors
         @input = BetterErrors::REPL::Pry::Input.new
         @output = BetterErrors::REPL::Pry::Output.new
         @pry = ::Pry.new input: @input, output: @output
-        @pry.hooks.clear_all if defined?(@pry.hooks.clear_all)
+        @pry.hooks.clear_event_hooks(:before_session) if @pry.hooks.respond_to?(:clear_event_hooks) # pry version >= 0.11.x
+        @pry.hooks.clear_all if @pry.hooks.respond_to?(:clear_all) # pry version <= 0.10.x
         store_last_exception exception
         @fiber.resume
       end


### PR DESCRIPTION
This pullrequest solve the problem that REPL response display source code on first request, and contain color escape code if we use pry (>= 0.11.0) for REPL.

REPL response sample before (contain source code with color escape code)
```
\e[1mFrom:\e[0m /Users/hoge/rails5/hoge.rb @ line 10 :

     \e[1;34m5\e[0m:         raise
     \e[1;34m6\e[0m:     \e[32mrescue\e[0m => e
     \e[1;34m7\e[0m:         e
     \e[1;34m8\e[0m:     \e[32mend\e[0m
     \e[1;34m9\e[0m: 
 => \e[1;34m10\e[0m: ins = \e[1;34;4mBetterErrors\e[0m::\e[1;34;4mREPL\e[0m::\e[1;34;4mPry\e[0m.new(binding, e)
    \e[1;34m11\e[0m: pp ins.send_input(\e[31m\e[1;31m'\e[0m\e[31m1*2\e[1;31m'\e[0m\e[31m\e[0m)
    \e[1;34m12\e[0m: pp ins.send_input(\e[31m\e[1;31m'\e[0m\e[31m3\e[1;31m'\e[0m\e[31m\e[0m)

 => \e[1;34m1\e[0m
```

after(this pullrequest), it contains only REPL response, so does not contain source code with color escape code.
```
 => 1
```