### PR TITLE
Fix NoMethodError when variables cannot be retrieved from the stack frame

### DIFF
--- a/lib/better_errors/stack_frame.rb
+++ b/lib/better_errors/stack_frame.rb
@@ -69,7 +69,10 @@ module BetterErrors
     def local_variables
       return {} unless frame_binding
 
-      frame_binding.eval("local_variables").each_with_object({}) do |name, hash|
+      lv = frame_binding.eval("local_variables")
+      return {} unless lv
+
+      lv.each_with_object({}) do |name, hash|
         # Ruby 2.2's local_variables will include the hidden #$! variable if
         # called from within a rescue context. This is not a valid variable name,
         # so the local_variable_get method complains. This should probably be
@@ -94,7 +97,10 @@ module BetterErrors
     end
 
     def visible_instance_variables
-      frame_binding.eval("instance_variables") - BetterErrors.ignored_instance_variables
+      iv = frame_binding.eval("instance_variables")
+      return {} unless iv
+
+      iv - BetterErrors.ignored_instance_variables
     end
 
     def to_s


### PR DESCRIPTION
This seems to affect only Jbuilder frames in a Rails 5.1 app. Calling `eval("local_variables")` returns nil in any jbuilder frame. I'm working on a reproducible case for this and a spec to cover it.

```
NoMethodError (undefined method `each_with_object' for nil:NilClass):

better_errors (2.5.0) lib/better_errors/stack_frame.rb:72:in `local_variables'
better_errors (2.5.0) lib/better_errors/error_page.rb:82:in `render'
better_errors (2.5.0) lib/better_errors/error_page.rb:30:in `eval'
better_errors (2.5.0) lib/better_errors/error_page.rb:30:in `render'
better_errors (2.5.0) lib/better_errors/error_page.rb:37:in `do_variables'
better_errors (2.5.0) lib/better_errors/middleware.rb:137:in `internal_call'
better_errors (2.5.0) lib/better_errors/middleware.rb:75:in `better_errors_call'
better_errors (2.5.0) lib/better_errors/middleware.rb:57:in `call'
actionpack (5.1.6) lib/action_dispatch/middleware/debug_exceptions.rb:59:in `call'
web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
actionpack (5.1.6) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
railties (5.1.6) lib/rails/rack/logger.rb:36:in `call_app'
railties (5.1.6) lib/rails/rack/logger.rb:24:in `block in call'
activesupport (5.1.6) lib/active_support/tagged_logging.rb:69:in `block in tagged'
activesupport (5.1.6) lib/active_support/tagged_logging.rb:26:in `tagged'
activesupport (5.1.6) lib/active_support/tagged_logging.rb:69:in `tagged'
railties (5.1.6) lib/rails/rack/logger.rb:24:in `call'
sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
actionpack (5.1.6) lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
request_store (1.4.1) lib/request_store/middleware.rb:19:in `call'
actionpack (5.1.6) lib/action_dispatch/middleware/request_id.rb:25:in `call'
rack (2.0.5) lib/rack/method_override.rb:22:in `call'
rack (2.0.5) lib/rack/runtime.rb:22:in `call'
activesupport (5.1.6) lib/active_support/cache/strategy/local_cache_middleware.rb:27:in `call'
actionpack (5.1.6) lib/action_dispatch/middleware/executor.rb:12:in `call'
actionpack (5.1.6) lib/action_dispatch/middleware/static.rb:125:in `call'
rack (2.0.5) lib/rack/sendfile.rb:111:in `call'
rack-reverse-proxy (0.12.0) lib/rack_reverse_proxy/roundtrip.rb:19:in `call'
rack-reverse-proxy (0.12.0) lib/rack_reverse_proxy/middleware.rb:25:in `call'
sentry-raven (2.7.4) lib/raven/integrations/rack.rb:51:in `call'
webpacker (3.5.5) lib/webpacker/dev_server_proxy.rb:22:in `perform_request'
rack-proxy (0.6.5) lib/rack/proxy.rb:57:in `call'
railties (5.1.6) lib/rails/engine.rb:522:in `call'
puma (3.12.0) lib/puma/configuration.rb:225:in `call'
puma (3.12.0) lib/puma/server.rb:658:in `handle_request'
puma (3.12.0) lib/puma/server.rb:472:in `process_client'
puma (3.12.0) lib/puma/server.rb:332:in `block in run'
puma (3.12.0) lib/puma/thread_pool.rb:133:in `block in spawn_thread'
```