### PR TITLE
fix TypeError when inspection of instance of anonymous class is large

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -108,7 +108,7 @@ module BetterErrors
       InspectableValue.new(obj).to_html
     rescue BetterErrors::ValueLargerThanConfiguredMaximum
       "<span class='unsupported'>(object too large. "\
-        "Modify #{CGI.escapeHTML(obj.class.name)}#inspect "\
+        "Modify #{CGI.escapeHTML(obj.class.name.to_s)}#inspect "\
         "or adjust BetterErrors.maximum_variable_inspect_size)</span>"
     rescue Exception => e
       "<span class='unsupported'>(exception #{CGI.escapeHTML(e.class.to_s)} was raised in inspect)</span>"


### PR DESCRIPTION
We sometimes see objects that are instances of anonymous classes which have large inspection strings, and the whole request dies because `obj.class.name` is nil which at https://github.com/BetterErrors/better_errors/blob/ad519b7fb4b7179d38085782521584c2b3b2eaae/lib/better_errors/error_page.rb#L111 results in a TypeError.

Bug introduced in version 2.5.0 by commit https://github.com/BetterErrors/better_errors/commit/f1c2fdc219409513cf64e8adb1f132598374ee68

Throwing a to_s on the end works for me.
