### PR TITLE
Fall back to older rubygems on Ruby 2.2 and Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: ruby
 cache: bundler
 before_install:
-  - gem update --system
+  # Since rubygems 3.0+ only support Ruby 2.3+, we must install the old version for older Rubies.
+  - if [[ `ruby -v` == *"ruby 2.2"* ]]; then gem install rubygems-update -v '<3'; update_rubygems; else gem update --system; fi
   - gem update bundler
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,6 @@
 sudo: false
 language: ruby
 cache: bundler
-before_install:
-  # Since rubygems 3.0+ only supports Ruby 2.3+, we must install the old version for older Rubies.
-  # Since Rails 4.2 only supports rubygems < 2, we must install an even older version for it.
-  - >
-    if [[ "$BUNDLE_GEMFILE" =~ "rails42" ]]; then
-      rvm @global do gem install rubygems-update -v '<2'
-      update_rubygems
-      rvm @global do gem uninstall bundler --force --executables
-      rvm @global do gem install bundler -v "~> 1.3"
-    elif [[ `ruby -v` == *"ruby 2.2"* ]]; then
-      rvm @global do gem install rubygems-update -v '<3'
-      update_rubygems
-      rvm @global do gem uninstall bundler --force --executables
-      rvm @global do gem install bundler
-    else
-      rvm @global do gem update --system
-      rvm @global do gem uninstall bundler --force --executables
-      rvm @global do gem install bundler
-    fi
-
 notifications:
   webhooks:
     # With COVERALLS_PARALLEL, coverage information sent to coveralls will not be processed until

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 sudo: false
 language: ruby
 cache: bundler
+before_install:
+  # Since Rails 4.2 only supports rubygems < 2, we must install an older version for it.
+  - >
+    if [[ "$BUNDLE_GEMFILE" =~ "rails42" ]]; then
+      rvm @global do gem install rubygems-update -v '<2'
+      update_rubygems
+      rvm @global do gem uninstall bundler --force --executables
+      rvm @global do gem install bundler -v "~> 1.3"
+    fi
+
 notifications:
   webhooks:
     # With COVERALLS_PARALLEL, coverage information sent to coveralls will not be processed until

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,17 @@ before_install:
     if [[ "$BUNDLE_GEMFILE" =~ "rails42" ]]; then
       gem install rubygems-update -v '<2'
       update_rubygems
+      gem uninstall bundler --force --executables
+      gem install bundler -v "~> 1.3"
     elif [[ `ruby -v` == *"ruby 2.2"* ]]; then
       gem install rubygems-update -v '<3'
       update_rubygems
+      gem update bundler
     else
       gem update --system
+      gem update bundler
     fi
 
-  - gem update bundler
 notifications:
   webhooks:
     # With COVERALLS_PARALLEL, coverage information sent to coveralls will not be processed until

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,19 @@ sudo: false
 language: ruby
 cache: bundler
 before_install:
-  # Since rubygems 3.0+ only support Ruby 2.3+, we must install the old version for older Rubies.
-  - if [[ `ruby -v` == *"ruby 2.2"* ]]; then gem install rubygems-update -v '<3'; update_rubygems; else gem update --system; fi
+  # Since rubygems 3.0+ only supports Ruby 2.3+, we must install the old version for older Rubies.
+  # Since Rails 4.2 only supports rubygems < 2, we must install an even older version for it.
+  - >
+    if [[ "$BUNDLE_GEMFILE" =~ "rails42" ]]; then
+      gem install rubygems-update -v '<2'
+      update_rubygems
+    elif [[ `ruby -v` == *"ruby 2.2"* ]]; then
+      gem install rubygems-update -v '<3'
+      update_rubygems
+    else
+      gem update --system
+    fi
+
   - gem update bundler
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ before_install:
   # Since Rails 4.2 only supports rubygems < 2, we must install an even older version for it.
   - >
     if [[ "$BUNDLE_GEMFILE" =~ "rails42" ]]; then
-      gem install rubygems-update -v '<2'
+      rvm @global do gem install rubygems-update -v '<2'
       update_rubygems
-      gem uninstall bundler --force --executables
-      gem install bundler -v "~> 1.3"
+      rvm @global do gem uninstall bundler --force --executables
+      rvm @global do gem install bundler -v "~> 1.3"
     elif [[ `ruby -v` == *"ruby 2.2"* ]]; then
-      gem install rubygems-update -v '<3'
+      rvm @global do gem install rubygems-update -v '<3'
       update_rubygems
-      gem update bundler
+      rvm @global do gem update bundler --force --executables
     else
-      gem update --system
-      gem update bundler
+      rvm @global do gem update --system
+      rvm @global do gem update bundler --force --executables
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ before_install:
     elif [[ `ruby -v` == *"ruby 2.2"* ]]; then
       rvm @global do gem install rubygems-update -v '<3'
       update_rubygems
-      rvm @global do gem update bundler --force --executables
+      rvm @global do gem uninstall bundler --force --executables
+      rvm @global do gem install bundler
     else
       rvm @global do gem update --system
-      rvm @global do gem update bundler --force --executables
+      rvm @global do gem uninstall bundler --force --executables
+      rvm @global do gem install bundler
     fi
 
 notifications:


### PR DESCRIPTION
Currently CI builds are failing because it's always trying to upgrade rubygems to the latest. The latest version of rubygems refuses to install on ruby <= 2.2.

In addition, the latest version of Bundler refuses to install with an older version of Rubygems, and Rails 4.2 is incompatible with the latest version of Bundler.

Implemented a [suggested fix](https://github.com/rubygems/rubygems/issues/2534) for this so that older Ruby versions will install a version-restricted rubygems and then run it, while newer Ruby versions will continue as before.
