### PR TITLE
Adds simplecov as a development dependencie

### DIFF
--- a/better_errors.gemspec
+++ b/better_errors.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "yard"
   s.add_development_dependency "kramdown"
+  s.add_development_dependency "simplecov"
 
   s.add_dependency "erubi", ">= 1.0.0"
   s.add_dependency "coderay", ">= 1.0.0"


### PR DESCRIPTION
Without `simplecov` `bundle exec rspec` gives a bunch of errors like:

```
An error occurred while loading ./spec/better_errors/code_formatter_spec.rb.
Failure/Error: require 'simplecov'

LoadError:
  cannot load such file -- simplecov
# ./spec/spec_helper.rb:16:in `require'
# ./spec/spec_helper.rb:16:in `<top (required)>'
# ./spec/better_errors/code_formatter_spec.rb:1:in `require'
# ./spec/better_errors/code_formatter_spec.rb:1:in `<top (required)>'
```