### PR TITLE
Fix exception when large object's class is anonymous

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -107,9 +107,9 @@ module BetterErrors
     def inspect_value(obj)
       InspectableValue.new(obj).to_html
     rescue BetterErrors::ValueLargerThanConfiguredMaximum
-      "<span class='unsupported'>(object too large. "\
-        "Modify #{CGI.escapeHTML(obj.class.name || obj.class.to_s)}#inspect "\
-        "or adjust BetterErrors.maximum_variable_inspect_size)</span>"
+      "<span class='unsupported'>(Object too large. "\
+        "#{obj.class.name ? "Modify #{CGI.escapeHTML(obj.class.name)}#inspect or a" : "A"}"\
+        "djust BetterErrors.maximum_variable_inspect_size if you need to see it.)</span>"
     rescue Exception => e
       "<span class='unsupported'>(exception #{CGI.escapeHTML(e.class.to_s)} was raised in inspect)</span>"
     end

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -108,7 +108,7 @@ module BetterErrors
       InspectableValue.new(obj).to_html
     rescue BetterErrors::ValueLargerThanConfiguredMaximum
       "<span class='unsupported'>(object too large. "\
-        "Modify #{CGI.escapeHTML(obj.class.name)}#inspect "\
+        "Modify #{CGI.escapeHTML(obj.class.name || obj.class.to_s)}#inspect "\
         "or adjust BetterErrors.maximum_variable_inspect_size)</span>"
     rescue Exception => e
       "<span class='unsupported'>(exception #{CGI.escapeHTML(e.class.to_s)} was raised in inspect)</span>"

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -121,6 +121,25 @@ module BetterErrors
                   expect(html).to include("object too large")
                 end
               end
+
+              context "fallbacks to class to_s when variable class is anonymous" do
+                let(:exception_binding) {
+                  @big_anonymous = Class.new do
+                    def initialize
+                      @content = 'A' * 1101
+                    end
+                  end.new
+
+                  binding
+                }
+                
+                it "shows the class to_s" do
+                  html = error_page.do_variables("index" => 0)[:html]
+                  expect(html).to include('<td class="name">' + '@big_anonymous</td>')
+                  expect(html).to include('object too large')
+                  expect(html).to match(/#&lt;Class:0x[[:xdigit:]]+&gt;#inspect/)
+                end
+              end
             end
           end
           context 'on a platform without ObjectSpace' do
@@ -182,6 +201,25 @@ module BetterErrors
                   expect(html).to_not include(content)
                   expect(html).to include("object too large")
                 end
+              end
+            end
+
+            context "fallbacks to class to_s when variable class is anonymous" do
+              let(:exception_binding) {
+                @big_anonymous = Class.new do
+                  def initialize
+                    @content = 'A' * 1101
+                  end
+                end.new
+
+                binding
+              }
+              
+              it "shows the class to_s" do
+                html = error_page.do_variables("index" => 0)[:html]
+                expect(html).to include('<td class="name">' + '@big_anonymous</td>')
+                expect(html).to include('object too large')
+                expect(html).to match(/#&lt;Class:0x[[:xdigit:]]+&gt;#inspect/)
               end
             end
           end

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -118,11 +118,11 @@ module BetterErrors
                 it "includes an indication that the variable was too large" do
                   html = error_page.do_variables("index" => 0)[:html]
                   expect(html).to_not include(content)
-                  expect(html).to include("object too large")
+                  expect(html).to include("Object too large")
                 end
               end
 
-              context "fallbacks to class to_s when variable class is anonymous" do
+              context "when the variable's class is anonymous" do
                 let(:exception_binding) {
                   @big_anonymous = Class.new do
                     def initialize
@@ -132,12 +132,12 @@ module BetterErrors
 
                   binding
                 }
-                
-                it "shows the class to_s" do
+
+                it "does not attempt to show the class name" do
                   html = error_page.do_variables("index" => 0)[:html]
                   expect(html).to include('<td class="name">' + '@big_anonymous</td>')
-                  expect(html).to include('object too large')
-                  expect(html).to match(/#&lt;Class:0x[[:xdigit:]]+&gt;#inspect/)
+                  expect(html).to include('Object too large')
+                  expect(html).to include('Adjust BetterErrors.maximum_variable_inspect_size')
                 end
               end
             end
@@ -199,12 +199,12 @@ module BetterErrors
                 it "includes an indication that the variable was too large" do
                   html = error_page.do_variables("index" => 0)[:html]
                   expect(html).to_not include(content)
-                  expect(html).to include("object too large")
+                  expect(html).to include("Object too large")
                 end
               end
             end
 
-            context "fallbacks to class to_s when variable class is anonymous" do
+            context "when the variable's class is anonymous" do
               let(:exception_binding) {
                 @big_anonymous = Class.new do
                   def initialize
@@ -214,12 +214,12 @@ module BetterErrors
 
                 binding
               }
-              
-              it "shows the class to_s" do
+
+              it "does not attempt to show the class name" do
                 html = error_page.do_variables("index" => 0)[:html]
                 expect(html).to include('<td class="name">' + '@big_anonymous</td>')
-                expect(html).to include('object too large')
-                expect(html).to match(/#&lt;Class:0x[[:xdigit:]]+&gt;#inspect/)
+                expect(html).to include('Object too large')
+                expect(html).to include('Adjust BetterErrors.maximum_variable_inspect_size')
               end
             end
           end
@@ -240,7 +240,7 @@ module BetterErrors
           it "includes the content of large variables" do
             html = error_page.do_variables("index" => 0)[:html]
             expect(html).to include(content)
-            expect(html).to_not include("object too large")
+            expect(html).to_not include("Object too large")
           end
         end
       else


### PR DESCRIPTION
Avoids the error pointed by https://github.com/BetterErrors/better_errors/issues/411#issuecomment-462005513

When a local/instance variable is anonymous and it's value is too large better_errors prints a default message in https://github.com/BetterErrors/better_errors/blob/master/lib/better_errors/error_page.rb#L111

This pull request adds a fallback to use `obj.class.to_s`, since `obj.class.name` returns nil for anonymous classes causing the following exception:

```
00:23:25 web.1      | Started POST "/admin/__better_errors/50c95030d470e258/variables" for ::1 at 2019-02-09 00:23:25 -0200
00:23:26 web.1      |   
00:23:26 web.1      | TypeError (no implicit conversion of nil into String):
00:23:26 web.1      |   
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:111:in `escapeHTML'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:111:in `rescue in inspect_value'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:107:in `inspect_value'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:94:in `block in render'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:93:in `each'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:93:in `render'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:30:in `eval'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:30:in `render'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/error_page.rb:37:in `do_variables'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/middleware.rb:137:in `internal_call'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/middleware.rb:75:in `better_errors_call'
00:23:26 web.1      | better_errors (2.5.0) lib/better_errors/middleware.rb:57:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:30:in `call'
00:23:26 web.1      | web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
00:23:26 web.1      | web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
00:23:26 web.1      | web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
00:23:26 web.1      | web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/railties/lib/rails/rack/logger.rb:38:in `call_app'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/railties/lib/rails/rack/logger.rb:26:in `block in call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/activesupport/lib/active_support/tagged_logging.rb:80:in `block in tagged'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/activesupport/lib/active_support/tagged_logging.rb:28:in `tagged'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/activesupport/lib/active_support/tagged_logging.rb:80:in `tagged'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/railties/lib/rails/rack/logger.rb:26:in `call'
00:23:26 web.1      | sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/request_id.rb:27:in `call'
00:23:26 web.1      | rack (2.0.6) lib/rack/method_override.rb:22:in `call'
00:23:26 web.1      | rack (2.0.6) lib/rack/runtime.rb:22:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/executor.rb:14:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/static.rb:126:in `call'
00:23:26 web.1      | rack (2.0.6) lib/rack/sendfile.rb:111:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/actionpack/lib/action_dispatch/middleware/host_authorization.rb:83:in `call'
00:23:26 web.1      | webpacker (3.5.5) lib/webpacker/dev_server_proxy.rb:22:in `perform_request'
00:23:26 web.1      | rack-proxy (0.6.5) lib/rack/proxy.rb:57:in `call'
00:23:26 web.1      | /home/kadu/sources/rails-dev-box/rails/railties/lib/rails/engine.rb:524:in `call'
00:23:26 web.1      | puma (3.12.0) lib/puma/configuration.rb:225:in `call'
00:23:26 web.1      | puma (3.12.0) lib/puma/server.rb:658:in `handle_request'
00:23:26 web.1      | puma (3.12.0) lib/puma/server.rb:472:in `process_client'
00:23:26 web.1      | puma (3.12.0) lib/puma/server.rb:332:in `block in run'
00:23:26 web.1      | puma (3.12.0) lib/puma/thread_pool.rb:133:in `block in spawn_thread'
00:23:26 web.1      | Error occurred while parsing request parameters.
00:23:26 web.1      | Contents:
00:23:26 web.1      | 
00:23:26 web.1      |
```