### PR TITLE
Specify older kramdown and i18n for older ruby versions

### DIFF
--- a/better_errors.gemspec
+++ b/better_errors.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "yard"
-  s.add_development_dependency "kramdown"
+  # kramdown 2.1 requires Ruby 2.3+
+  s.add_development_dependency "kramdown", (RUBY_VERSION < '2.3' ? '< 2.0.0' : '> 2.0.0')
   # simplecov and coveralls must not be included here. See the Gemfiles instead.
 
   s.add_dependency "erubi", ">= 1.0.0"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 gem 'nokogiri', RUBY_VERSION < '2.1' ? '~> 1.6.0' : '>= 1.7'
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 
 gem 'coveralls', require: false
 

--- a/gemfiles/rails42_boc.gemfile
+++ b/gemfiles/rails42_boc.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 gem 'nokogiri', RUBY_VERSION < '2.1' ? '~> 1.6.0' : '>= 1.7'
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "binding_of_caller"
 
 gem 'coveralls', require: false

--- a/gemfiles/rails42_haml.gemfile
+++ b/gemfiles/rails42_haml.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 gem 'nokogiri', RUBY_VERSION < '2.1' ? '~> 1.6.0' : '>= 1.7'
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "haml"
 
 gem 'coveralls', require: false

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 
 gem 'coveralls', require: false
 

--- a/gemfiles/rails50_boc.gemfile
+++ b/gemfiles/rails50_boc.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "binding_of_caller"
 
 gem 'coveralls', require: false

--- a/gemfiles/rails50_haml.gemfile
+++ b/gemfiles/rails50_haml.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "haml"
 
 gem 'coveralls', require: false

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
+gem 'i18n', '< 1.5.2', require: false if RUBY_VERSION < '2.3'
 
 gem 'coveralls', require: false
 

--- a/gemfiles/rails51_boc.gemfile
+++ b/gemfiles/rails51_boc.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "binding_of_caller"
 
 gem 'coveralls', require: false

--- a/gemfiles/rails51_haml.gemfile
+++ b/gemfiles/rails51_haml.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "haml"
 
 gem 'coveralls', require: false

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 
 gem 'coveralls', require: false
 

--- a/gemfiles/rails52_boc.gemfile
+++ b/gemfiles/rails52_boc.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "binding_of_caller"
 
 gem 'coveralls', require: false

--- a/gemfiles/rails52_haml.gemfile
+++ b/gemfiles/rails52_haml.gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem 'i18n', '< 1.5.2' if RUBY_VERSION < '2.3'
 gem "haml"
 
 gem 'coveralls', require: false


### PR DESCRIPTION
[CI failure](https://travis-ci.org/BetterErrors/better_errors/builds/493285669) was caused by [kramdown 2.0+ requiring Ruby 2.3+](https://kramdown.gettalong.org/news.html). This fixes it by specifying the older kramdown version when the current Ruby version is older than 2.3.

Same for i18n 1.5.2, which is a dependency of Rails, not a development dependency.
