### PR TITLE
Allow passing IPAddrs to allow_ip

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -33,7 +33,7 @@ module BetterErrors
     # Adds an address to the set of IP addresses allowed to access Better
     # Errors.
     def self.allow_ip!(addr)
-      ALLOWED_IPS << IPAddr.new(addr)
+      ALLOWED_IPS << (addr.is_a?(IPAddr) ? addr : IPAddr.new(addr))
     end
 
     allow_ip! "127.0.0.0/8"

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -40,6 +40,12 @@ module BetterErrors
       app.call("REMOTE_ADDR" => "77.55.33.11")
     end
 
+    it "shows to a whitelisted IPAddr" do
+      BetterErrors::Middleware.allow_ip! IPAddr.new('77.55.33.0/24')
+      expect(app).to receive :better_errors_call
+      app.call("REMOTE_ADDR" => "77.55.33.11")
+    end
+
     it "respects the X-Forwarded-For header" do
       expect(app).not_to receive :better_errors_call
       app.call(


### PR DESCRIPTION
Can we add support for passing IPAddrs directly to allow_ip?