### PR TITLE
Clear error page state before each request

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -81,6 +81,7 @@ module BetterErrors
     end
 
     def protected_app_call(env)
+      @error_page = nil
       @app.call env
     rescue Exception => ex
       @error_page = @handler.new ex, env


### PR DESCRIPTION
This clears out the @error_page state before each request to avoid
dirtying the error state of subsequent requests. For example a name
error in the controller will cause an inspect call on the controller
instance that will then also inspect the @error_page ivar referenced
through the rack env in the controller. One possible side-effect of
this are excessive database queries for unloaded relations.

This also should reduce memory usage, since the app can garbage collect
the no longer referenced state, delete temp files, etc.

For more info see the discussion on: https://github.com/rails/rails/pull/38445