### PR TITLE
Allow skipping variable inspection by class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ See [the wiki for instructions on configuring the editor](https://github.com/Bet
 BetterErrors.maximum_variable_inspect_size = 100_000
 ```
 
+## Ignore inspection of variables with certain classes.
+
+```ruby
+# e.g. in config/initializers/better_errors.rb
+# This will stop BetterErrors from trying to inspect objects of these classes, which can cause
+# slow loading times and unneccessary database queries. Does not check inheritance chain, use
+# strings not contants.
+# default value: ['ActionDispatch::Request', 'ActionDispatch::Response']
+BetterErrors.ignored_classes = ['ActionDispatch::Request', 'ActionDispatch::Response']
+```
 
 ## Get in touch!
 

--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -54,9 +54,14 @@ module BetterErrors
     # the variable won't be returned.
     # @return int
     attr_accessor :maximum_variable_inspect_size
+
+    # List of classes that are excluded from inspection.
+    # @return [Array]
+    attr_accessor :ignored_classes
   end
   @ignored_instance_variables = []
   @maximum_variable_inspect_size = 100_000
+  @ignored_classes = ['ActionDispatch::Request', 'ActionDispatch::Response']
 
   # Returns a proc, which when called with a filename and line number argument,
   # returns a URL to open the filename and line in the selected editor.

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -106,7 +106,7 @@ module BetterErrors
 
     def inspect_value(obj)
       if BetterErrors.ignored_classes.include? obj.class.name
-        "<span class='unsupported'>(Class ignored. "\
+        "<span class='unsupported'>(Instance of ignored class. "\
         "#{obj.class.name ? "Remove #{CGI.escapeHTML(obj.class.name)} from" : "Modify"}"\
         " BetterErrors.ignored_classes if you need to see it.)</span>"
       else

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -105,7 +105,13 @@ module BetterErrors
     end
 
     def inspect_value(obj)
-      InspectableValue.new(obj).to_html
+      if BetterErrors.ignored_classes.include? obj.class.name
+        "<span class='unsupported'>(Class ignored. "\
+        "#{obj.class.name ? "Remove #{CGI.escapeHTML(obj.class.name)} from" : "Modify"}"\
+        " BetterErrors.ignored_classes if you need to see it.)</span>"
+      else
+        InspectableValue.new(obj).to_html
+      end
     rescue BetterErrors::ValueLargerThanConfiguredMaximum
       "<span class='unsupported'>(Object too large. "\
         "#{obj.class.name ? "Modify #{CGI.escapeHTML(obj.class.name)}#inspect or a" : "A"}"\

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -92,7 +92,7 @@ module BetterErrors
             end
             expect(html).to have_tag('div.variables tr') do
               with_tag('td.name', text: 'local_b')
-              with_tag('.unsupported', text: /Instance of ErrorPageTestIgnoredClass ignored/)
+              with_tag('.unsupported', text: /Instance of ignored class/)
               with_tag('.unsupported', text: /BetterErrors\.ignored_classes/)
             end
             expect(html).to have_tag('div.variables tr') do
@@ -101,7 +101,7 @@ module BetterErrors
             end
             expect(html).to have_tag('div.variables tr') do
               with_tag('td.name', text: '@inst_d')
-              with_tag('.unsupported', text: /Instance of ErrorPageTestIgnoredClass ignored./)
+              with_tag('.unsupported', text: /Instance of ignored class/)
               with_tag('.unsupported', text: /BetterErrors\.ignored_classes/)
             end
           end

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -10,10 +10,10 @@ module BetterErrors
 
     let(:exception_binding) {
       local_a = :value_for_local_a
-      local_b = :value_for_local_b
+      local_b = "value_for_local_b"
 
       @inst_c = :value_for_inst_c
-      @inst_d = :value_for_inst_d
+      @inst_d = "value_for_inst_d"
 
       binding
     }
@@ -39,7 +39,7 @@ module BetterErrors
           expect(html).to include('<td class="name">local_a</td>')
           expect(html).to include("<pre>:value_for_local_a</pre>")
           expect(html).to include('<td class="name">local_b</td>')
-          expect(html).to include("<pre>:value_for_local_b</pre>")
+          expect(html).to include('<pre>"value_for_local_b"</pre>')
         end
 
         it "shows instance variables" do
@@ -47,7 +47,7 @@ module BetterErrors
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).to include('<td class="name">' + '@inst_d</td>')
-          expect(html).to include("<pre>" + ":value_for_inst_d</pre>")
+          expect(html).to include("<pre>" + '"value_for_inst_d"</pre>')
         end
 
         it "does not show filtered variables" do
@@ -56,7 +56,7 @@ module BetterErrors
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).not_to include('<td class="name">' + '@inst_d</td>')
-          expect(html).not_to include("<pre>" + ":value_for_inst_d</pre>")
+          expect(html).not_to include("<pre>" + '"value_for_inst_d"</pre>')
         end
 
         it "does not inspect value of ignored classes" do
@@ -65,11 +65,11 @@ module BetterErrors
           expect(html).to include('<td class="name">local_a</td>')
           expect(html).not_to include("<pre>:value_for_local_a</pre>")
           expect(html).to include('<td class="name">local_b</td>')
-          expect(html).not_to include("<pre>:value_for_local_b</pre>")
+          expect(html).to include('<pre>"value_for_local_b"</pre>')
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).not_to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).to include('<td class="name">' + '@inst_d</td>')
-          expect(html).not_to include("<pre>" + ":value_for_inst_d</pre>")
+          expect(html).to include("<pre>" + '"value_for_inst_d"</pre>')
           expect(html).to include("(Class ignored. Remove Symbol from BetterErrors.ignored_classes if you need to see it.)")
         end
 

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -10,10 +10,10 @@ module BetterErrors
 
     let(:exception_binding) {
       local_a = :value_for_local_a
-      local_b = "value_for_local_b"
+      local_b = :value_for_local_b
 
       @inst_c = :value_for_inst_c
-      @inst_d = "value_for_inst_d"
+      @inst_d = :value_for_inst_d
 
       binding
     }
@@ -39,7 +39,7 @@ module BetterErrors
           expect(html).to include('<td class="name">local_a</td>')
           expect(html).to include("<pre>:value_for_local_a</pre>")
           expect(html).to include('<td class="name">local_b</td>')
-          expect(html).to include('<pre>"value_for_local_b"</pre>')
+          expect(html).to include("<pre>:value_for_local_b</pre>")
         end
 
         it "shows instance variables" do
@@ -47,7 +47,7 @@ module BetterErrors
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).to include('<td class="name">' + '@inst_d</td>')
-          expect(html).to include("<pre>" + '"value_for_inst_d"</pre>')
+          expect(html).to include("<pre>" + ":value_for_inst_d</pre>")
         end
 
         it "does not show filtered variables" do
@@ -56,7 +56,7 @@ module BetterErrors
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).not_to include('<td class="name">' + '@inst_d</td>')
-          expect(html).not_to include("<pre>" + '"value_for_inst_d"</pre>')
+          expect(html).not_to include("<pre>" + ":value_for_inst_d</pre>")
         end
 
         it "does not inspect value of ignored classes" do
@@ -65,11 +65,11 @@ module BetterErrors
           expect(html).to include('<td class="name">local_a</td>')
           expect(html).not_to include("<pre>:value_for_local_a</pre>")
           expect(html).to include('<td class="name">local_b</td>')
-          expect(html).to include('<pre>"value_for_local_b"</pre>')
+          expect(html).not_to include("<pre>:value_for_local_b</pre>")
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).not_to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).to include('<td class="name">' + '@inst_d</td>')
-          expect(html).to include("<pre>" + '"value_for_inst_d"</pre>')
+          expect(html).not_to include("<pre>" + ":value_for_inst_d</pre>")
           expect(html).to include("(Class ignored. Remove Symbol from BetterErrors.ignored_classes if you need to see it.)")
         end
 

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -10,10 +10,10 @@ module BetterErrors
 
     let(:exception_binding) {
       local_a = :value_for_local_a
-      local_b = :value_for_local_b
+      local_b = "value_for_local_b"
 
       @inst_c = :value_for_inst_c
-      @inst_d = :value_for_inst_d
+      @inst_d = "value_for_inst_d"
 
       binding
     }
@@ -39,7 +39,7 @@ module BetterErrors
           expect(html).to include('<td class="name">local_a</td>')
           expect(html).to include("<pre>:value_for_local_a</pre>")
           expect(html).to include('<td class="name">local_b</td>')
-          expect(html).to include("<pre>:value_for_local_b</pre>")
+          expect(html).to include('<pre>"value_for_local_b"</pre>')
         end
 
         it "shows instance variables" do
@@ -47,7 +47,7 @@ module BetterErrors
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).to include('<td class="name">' + '@inst_d</td>')
-          expect(html).to include("<pre>" + ":value_for_inst_d</pre>")
+          expect(html).to include("<pre>" + '"value_for_inst_d"</pre>')
         end
 
         it "does not show filtered variables" do
@@ -56,7 +56,21 @@ module BetterErrors
           expect(html).to include('<td class="name">' + '@inst_c</td>')
           expect(html).to include("<pre>" + ":value_for_inst_c</pre>")
           expect(html).not_to include('<td class="name">' + '@inst_d</td>')
-          expect(html).not_to include("<pre>" + ":value_for_inst_d</pre>")
+          expect(html).not_to include("<pre>" + '"value_for_inst_d"</pre>')
+        end
+
+        it "does not inspect value of ignored classes" do
+          allow(BetterErrors).to receive(:ignored_classes).and_return(['Symbol'])
+          html = error_page.do_variables("index" => 0)[:html]
+          expect(html).to include('<td class="name">local_a</td>')
+          expect(html).not_to include("<pre>:value_for_local_a</pre>")
+          expect(html).to include('<td class="name">local_b</td>')
+          expect(html).to include('<pre>"value_for_local_b"</pre>')
+          expect(html).to include('<td class="name">' + '@inst_c</td>')
+          expect(html).not_to include("<pre>" + ":value_for_inst_c</pre>")
+          expect(html).to include('<td class="name">' + '@inst_d</td>')
+          expect(html).to include("<pre>" + '"value_for_inst_d"</pre>')
+          expect(html).to include("(Class ignored. Remove Symbol from BetterErrors.ignored_classes if you need to see it.)")
         end
 
         context 'when maximum_variable_inspect_size is set' do


### PR DESCRIPTION
This adds a new global setting `BetterErrors.ignored_classes` that will skip inspecting the value of local and instance variables of this type.

The default setting ignores action dispatch request and response instances, which are usually not printed anyways due to exceeding the limit of `BetterErrors.maximum_variable_inspect_size`, but also avoids
all the memory allocations and database queries that are triggered by calling `#inspect` on variables.

The default setting was chosen to avoid excessive database queries for unloaded relations, because both the `ActionDispatch::Request` and the `ActionDispatch::Response` objects hold many references to the controller instance, causing the same instance variables to be inspected over and over again.
(See https://github.com/rails/rails/pull/38445 for details.)

This is a safer alternative to the undocumented setting `BetterErrors.ignored_instance_variables`, which could be set to `[:@_request, :@_response]` for Rails. It also doesn't completely hide the variables, but instead shows a message why the value was omitted, similar to `maximum_variable_inspect_size`.