### PR TITLE
Update CI Ruby to fix Travis CI failures problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
 sudo: false
 language: ruby
 cache: bundler
-before_install:
-  # Since Rails 4.2 only supports rubygems < 2, we must install an older version for it.
-  - >
-    if [[ "$BUNDLE_GEMFILE" =~ "rails42" ]]; then
-      rvm @global do gem install rubygems-update -v '<2'
-      update_rubygems
-      rvm @global do gem uninstall bundler --force --executables
-      rvm @global do gem install bundler -v "~> 1.3"
-    fi
-
 notifications:
   webhooks:
     # With COVERALLS_PARALLEL, coverage information sent to coveralls will not be processed until
@@ -19,9 +9,9 @@ notifications:
     - secure: "YnHYbTq51ySistjvOxsuNhyg4GLuUffEJstTYeGYXiBF7HG5h43IVYo8KNuLzwkgsOYBcNo+YMdQX7qCqJffSbhsr1FZRSzBmjFFxcyD4hu+ukM2theZ4mePVAZiePscYvQPRNY4hIb4d3egStJEytkalDhB3sOebF57tIaCssg="
 rvm:
   - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.9
+  - 2.5.7
   - ruby-head
 gemfile:
   - gemfiles/rails42.gemfile
@@ -48,15 +38,21 @@ matrix:
     - gemfile: gemfiles/pry010.gemfile
     - gemfile: gemfiles/pry011.gemfile
   exclude:
-    - rvm: 2.4.4
+    - rvm: 2.3.8
       gemfile: gemfiles/rails42.gemfile
-    - rvm: 2.4.4
+    - rvm: 2.3.8
       gemfile: gemfiles/rails42_boc.gemfile
-    - rvm: 2.4.4
+    - rvm: 2.3.8
       gemfile: gemfiles/rails42_haml.gemfile
-    - rvm: 2.5.1
+    - rvm: 2.4.9
       gemfile: gemfiles/rails42.gemfile
-    - rvm: 2.5.1
+    - rvm: 2.4.9
       gemfile: gemfiles/rails42_boc.gemfile
-    - rvm: 2.5.1
+    - rvm: 2.4.9
+      gemfile: gemfiles/rails42_haml.gemfile
+    - rvm: 2.5.7
+      gemfile: gemfiles/rails42.gemfile
+    - rvm: 2.5.7
+      gemfile: gemfiles/rails42_boc.gemfile
+    - rvm: 2.5.7
       gemfile: gemfiles/rails42_haml.gemfile


### PR DESCRIPTION
Update Rubies to latest minor version and exclude Rails 4.2 specs on Ruby 2.3, since the default bundler 2.1.2 gem breaks the downgrade.

Note that I tried to fix this first by using `export BUNDLER_VERSION=1.3`, which works fine locally to prefer Bundler 1.x, even if 2.x is installed, but for some reason that didn't work on Travis CI either.

If we really wanted to we could install bundler 1.17.3 and oveeride the install step to run `bundle _1.17.3_ install …`, but since Rails 4.2 is EOL imho the easiest thing is to just run the 4.2 specs on Ruby 2.2.10.
