### PR TITLE
Fix warning: __FILE__ in eval may not return location in binding

### DIFF
--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -36,8 +36,8 @@ module BetterErrors
 
     def setup_backtrace_from_bindings
       @backtrace = exception.__better_errors_bindings_stack.map { |binding|
-        file = binding.eval "__FILE__"
-        line = binding.eval "__LINE__"
+        file = binding.source_location[0]
+        line = binding.source_location[1]
         name = binding.frame_description
         StackFrame.new(file, line, name, binding)
       }

--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -36,8 +36,13 @@ module BetterErrors
 
     def setup_backtrace_from_bindings
       @backtrace = exception.__better_errors_bindings_stack.map { |binding|
-        file = binding.source_location[0]
-        line = binding.source_location[1]
+        if binding.respond_to?(:source_location) # Ruby >= 2.6
+          file = binding.source_location[0]
+          line = binding.source_location[1]
+        else
+          file = binding.eval "__FILE__"
+          line = binding.eval "__LINE__"
+        end
         name = binding.frame_description
         StackFrame.new(file, line, name, binding)
       }


### PR DESCRIPTION
When I used better_errors with rails-6.0.2.1 and ruby-2.7.0, I got the following warnings.

```
/Users/yuuu/src/github.com/fusic/mockmock-web/vendor/bundle/ruby/2.7.0/gems/better_errors-2.6.0/lib/better_errors/raised_exception.rb:40: warning: in `eval'
/Users/yuuu/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/bundler-2.1.2/libexec/bundle:46: warning: __FILE__ in eval may not return location in binding; use Binding#source_location instead
```

It has been modified to use Binding#source_location with reference to this issue.

https://github.com/pry/pry/issues/2097