### PR TITLE
Show the last-raised error, not its "cause"

### DIFF
--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -4,9 +4,8 @@ module BetterErrors
     attr_reader :exception, :message, :backtrace
 
     def initialize(exception)
-      if exception.respond_to?(:cause)
-        exception = exception.cause if exception.cause
-      elsif exception.respond_to?(:original_exception) && exception.original_exception
+      if exception.respond_to?(:original_exception) && exception.original_exception
+        # This supports some specific Rails exceptions, and is not intended to act the same as `#cause`.
         exception = exception.original_exception
       end
 


### PR DESCRIPTION
Fixes #296. More discussion in #433.

The change here is to not show the most recent exception raised. Previously on Ruby versions supporting `Exception#cause` it would show the most recent exception's cause if there was one.

The behavior in Rails of showing an "original exception" is still in place. This seems to be a desired behavior that's specific to ActionView template errors in Rails before 5.1.
