### PR TITLE
Show location of error in ActionView template error

### DIFF
--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -57,6 +57,10 @@ module BetterErrors
 
     def massage_syntax_error
       case exception.class.to_s
+      when "ActionView::Template::Error"
+        if exception.respond_to?(:file_name) && exception.respond_to?(:line_number)
+          backtrace.unshift(StackFrame.new(exception.file_name, exception.line_number.to_i, "view template"))
+        end
       when "Haml::SyntaxError", "Sprockets::Coffeelint::Error"
         if /\A(.+?):(\d+)/ =~ exception.backtrace.first
           backtrace.unshift(StackFrame.new($1, $2.to_i, ""))

--- a/spec/better_errors/raised_exception_spec.rb
+++ b/spec/better_errors/raised_exception_spec.rb
@@ -18,7 +18,7 @@ module BetterErrors
       its(:message)   { is_expected.to eq "something went wrong!" }
     end
 
-    context "when the exception is a syntax error" do
+    context "when the exception is a SyntaxError" do
       let(:exception) { SyntaxError.new("foo.rb:123: you made a typo!") }
 
       its(:message) { is_expected.to eq "you made a typo!" }
@@ -47,6 +47,35 @@ module BetterErrors
       it "has the right filename and line number in the backtrace" do
         expect(subject.backtrace.first.filename).to eq("foo.rb")
         expect(subject.backtrace.first.line).to eq(123)
+      end
+    end
+
+    context "when the exception is an ActionView::Template::Error" do
+      before do
+        stub_const(
+          "ActionView::Template::Error",
+          Class.new(StandardError) do
+            def file_name
+              "app/views/foo/bar.haml"
+            end
+
+            def line_number
+              42
+            end
+          end
+        )
+      end
+
+      let(:exception) {
+        ActionView::Template::Error.new("undefined method `something!' for #<Class:0x00deadbeef>")
+      }
+
+      its(:message) { is_expected.to eq "undefined method `something!' for #<Class:0x00deadbeef>" }
+      its(:type)    { is_expected.to eq ActionView::Template::Error }
+
+      it "has the right filename and line number in the backtrace" do
+        expect(subject.backtrace.first.filename).to eq("app/views/foo/bar.haml")
+        expect(subject.backtrace.first.line).to eq(42)
       end
     end
 


### PR DESCRIPTION
Fixes #461, fixes #462.

Previous to Rails 5.1, when an error was raised in a template, it included the location within the template in the backtrace. As of 5.1, the exception was replaced with an `ActionView::Template::Error` which provides `file_name` and `line_number` but does not include those in the backtrace.

![Showing the broken state, with a backtrace that does not include the template.](https://user-images.githubusercontent.com/1005280/81845383-7a33e400-951e-11ea-95ce-6f81d0de00a3.png)

`SyntaxError` and `Haml::SyntaxError` were handled specially by Better Errors, finding the filename and line number within the exception message and synthesizing a backtrace item based on those. The workaround for `ActionView::Template::Error` looks exactly like those.

The result is that the topmost backtrace item will be the location of the error within the template.

![The same error showing a backtrace including the template](https://user-images.githubusercontent.com/1005280/81845489-9e8fc080-951e-11ea-9cee-13d5947b90be.png)

