### PR TITLE
Support for Rails ActionableError

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -28,6 +28,11 @@ module BetterErrors
 
     def render(template_name = "main")
       binding.eval(self.class.template(template_name).src)
+    rescue => e
+      # Fix the backtrace, which doesn't identify the template that failed (within Better Errors).
+      # We don't know the line number, so just injecting the template path has to be enough.
+      e.backtrace.unshift "#{self.class.template_path(template_name)}:0"
+      raise
     end
 
     def do_variables(opts)

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -62,9 +62,16 @@ module BetterErrors
       exception.message.lstrip
     end
 
-    def exception_actions
+    def active_support_actions
       return [] unless defined?(ActiveSupport::ActionableError)
+
       ActiveSupport::ActionableError.actions(exception.type)
+    end
+
+    def action_dispatch_action_endpoint
+      return unless defined?(ActionDispatch::ActionableExceptions)
+
+      ActionDispatch::ActionableExceptions.endpoint
     end
 
     def application_frames

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -62,6 +62,11 @@ module BetterErrors
       exception.message.lstrip
     end
 
+    def exception_actions
+      return [] unless defined?(ActiveSupport::ActionableError)
+      ActiveSupport::ActionableError.actions(exception.type)
+    end
+
     def application_frames
       backtrace_frames.select(&:application?)
     end

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -59,7 +59,7 @@ module BetterErrors
     end
 
     def exception_message
-      exception.message.lstrip
+      exception.message.strip.gsub(/(\r?\n\s*\r?\n)+/, "\n")
     end
 
     def active_support_actions

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -744,6 +744,16 @@
         <header class="exception">
             <h2><strong><%= exception_type %></strong> <span>at <%= request_path %></span></h2>
             <p><%= exception_message %></p>
+            <% if exception_actions.any? %>
+                <% exception_actions.each do |action, _| %>
+                    <form class="button_to" method="post" action="<%= ActionDispatch::ActionableExceptions.endpoint %>">
+                        <input type="submit" value="<%= action %>">
+                        <input type="hidden" name="action" value="<%= action %>">
+                        <input type="hidden" name="error" value="<%= exception_type %>">
+                        <input type="hidden" name="location" value="<%= request_path %>">
+                    </form>
+                <% end %>
+            <% end %>
         </header>
     </div>
 

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -744,15 +744,17 @@
         <header class="exception">
             <h2><strong><%= exception_type %></strong> <span>at <%= request_path %></span></h2>
             <p><%= exception_message %></p>
-            <% if exception_actions.any? %>
-                <% exception_actions.each do |action, _| %>
-                    <form class="button_to" method="post" action="<%= ActionDispatch::ActionableExceptions.endpoint %>">
-                        <input type="submit" value="<%= action %>">
-                        <input type="hidden" name="action" value="<%= action %>">
-                        <input type="hidden" name="error" value="<%= exception_type %>">
-                        <input type="hidden" name="location" value="<%= request_path %>">
-                    </form>
-                <% end %>
+            <% unless active_support_actions.empty? %>
+                <div class='fix-actions'>
+                    <% active_support_actions.each do |action, _| %>
+                        <form class="button_to" method="post" action="<%= action_dispatch_action_endpoint %>">
+                            <input type="submit" value="<%= action %>">
+                            <input type="hidden" name="action" value="<%= action %>">
+                            <input type="hidden" name="error" value="<%= exception_type %>">
+                            <input type="hidden" name="location" value="<%= request_path %>">
+                        </form>
+                    <% end %>
+                </div>
             <% end %>
         </header>
     </div>

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -146,6 +146,14 @@
     }
 
     /* Heading */
+    header.exception .fix-actions {
+        margin-top: .5em;
+    }
+
+    header.exception .fix-actions input[type=submit] {
+        font-weight: bold;
+    }
+
     header.exception h2 {
         font-weight: 200;
         font-size: 11pt;
@@ -153,7 +161,7 @@
 
     header.exception h2,
     header.exception p {
-        line-height: 1.4em;
+        line-height: 1.5em;
         overflow: hidden;
         white-space: pre;
         text-overflow: ellipsis;
@@ -166,7 +174,7 @@
 
     header.exception p {
         font-weight: 200;
-        font-size: 20pt;
+        font-size: 17pt;
         color: white;
     }
 

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -63,7 +63,7 @@ module BetterErrors
         end
       end
 
-      context 'when ActiveSupport does provide any actions for this error type' do
+      context 'when ActiveSupport does not provide any actions for this error type' do
         let(:exception_class) {
           Class.new(StandardError)
         }

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -37,6 +37,44 @@ module BetterErrors
       expect(response).to have_tag('.exception h2', /ZeroDivisionError/)
     end
 
+    context 'when ActiveSupport::ActionableError is available' do
+      before do
+        skip "ActiveSupport missing on this platform" unless Object.constants.include?(:ActiveSupport)
+        skip "ActionableError missing on this platform" unless ActiveSupport.constants.include?(:ActionableError)
+      end
+
+      context 'when ActiveSupport provides one or more actions for this error type' do
+        let(:exception_class) {
+          Class.new(StandardError) do
+            include ActiveSupport::ActionableError
+
+            action "Do a thing" do
+              puts "Did a thing"
+            end
+          end
+        }
+        let(:exception) { exception_binding.eval("raise exception_class") rescue $! }
+
+        it "includes a fix-action form for each action" do
+          expect(response).to have_tag('.fix-actions') do
+            with_tag('form.button_to')
+            with_tag('form.button_to input[type=submit][value="Do a thing"]')
+          end
+        end
+      end
+
+      context 'when ActiveSupport does provide any actions for this error type' do
+        let(:exception_class) {
+          Class.new(StandardError)
+        }
+        let(:exception) { exception_binding.eval("raise exception_class") rescue $! }
+
+        it "does not include a fix-action form" do
+          expect(response).not_to have_tag('.fix-actions')
+        end
+      end
+    end
+
     context "variable inspection" do
       let(:exception) { exception_binding.eval("raise") rescue $! }
 


### PR DESCRIPTION
Fixes #443, fixes #455.

This adds support for actionable exceptions in Rails. For example, when a migration needs to be run it'll offer a button that can run the migrations for the user.

Original Actionable Errors PR in Rails: https://github.com/rails/rails/pull/34788

This is what the original PR uses to create the button:

```htmlerb
<%= button_to action, ActionDispatch::ActionableExceptions.endpoint, params: {
  error: exception.class.name,
  action: action,
  location: request.path
} %>
```

ActionView Helpers aren't loaded in the better errors view, so I instead opted to recreate the form myself using mostly the same variables. It's not a beautiful solution, but it works and I'm not sure if there's really a better way to work around that problem.

The button looks like this:

<img width="1439" alt="Screen Shot 2020-05-13 at 7 49 43 PM" src="https://user-images.githubusercontent.com/2977353/81883731-3909f700-9553-11ea-936a-15ab16ec1fe0.png">

It's hidden from the user behind the overflow, so it only shows up on hover. We could probably make it more obvious, but I'm not sure how exactly we should do it.

Reproduction steps:

- Add my fork of the better_errors gem to your Rails app. (`gem 'better_errors', git: 'https://github.com/connorshea/better_errors.git', branch: 'actionable-errors'`)
- Run a Rails app on at least 6.0 with `rails s` or whatever your equivalent is for your app.
- Run `rails g migration AddFooToBar` in your terminal
- Load any page in your app
- See a `PendingMigrationError`
- See that it now has a button to run the migrations.
- Click the button.
- See the migration has now been run.

We'll also want to make sure better_errors still works on versions before Rails 6 that don't have actionable errors, and I guess add a test to better_errors for this behavior?