### PR TITLE
Validate internal request method names

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -156,6 +156,8 @@ module BetterErrors
       body = JSON.parse(request.body.read)
       return invalid_csrf_token_json_response unless request.cookies[CSRF_TOKEN_COOKIE_NAME] == body['csrfToken']
 
+      return not_acceptable_json_response unless request.content_type == 'application/json'
+
       response = @error_page.send("do_#{opts[:method]}", body)
       [200, { "Content-Type" => "application/json; charset=utf-8" }, [JSON.dump(response)]]
     end
@@ -198,6 +200,13 @@ module BetterErrors
         error: "Invalid CSRF Token",
         explanation: "The browser session might have been cleared, " +
           "or something went wrong.",
+      )]]
+    end
+
+    def not_acceptable_json_response
+      [406, { "Content-Type" => "application/json; charset=utf-8" }, [JSON.dump(
+        error: "Request not acceptable",
+        explanation: "The internal request did not match an acceptable content type.",
       )]]
     end
   end

--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -75,7 +75,7 @@ module BetterErrors
     def better_errors_call(env)
       case env["PATH_INFO"]
       when %r{/__better_errors/(?<id>.+?)/(?<method>\w+)\z}
-        internal_call env, $~
+        internal_call(env, $~[:id], $~[:method])
       when %r{/__better_errors/?\z}
         show_error_page env
       else
@@ -145,9 +145,10 @@ module BetterErrors
       end
     end
 
-    def internal_call(env, opts)
+    def internal_call(env, id, method)
+      return not_found_json_response unless %w[variables eval].include?(method)
       return no_errors_json_response unless @error_page
-      return invalid_error_json_response if opts[:id] != @error_page.id
+      return invalid_error_json_response if id != @error_page.id
 
       request = Rack::Request.new(env)
       return invalid_csrf_token_json_response unless request.cookies[CSRF_TOKEN_COOKIE_NAME]
@@ -158,7 +159,7 @@ module BetterErrors
 
       return not_acceptable_json_response unless request.content_type == 'application/json'
 
-      response = @error_page.send("do_#{opts[:method]}", body)
+      response = @error_page.send("do_#{method}", body)
       [200, { "Content-Type" => "application/json; charset=utf-8" }, [JSON.dump(response)]]
     end
 
@@ -200,6 +201,13 @@ module BetterErrors
         error: "Invalid CSRF Token",
         explanation: "The browser session might have been cleared, " +
           "or something went wrong.",
+      )]]
+    end
+
+    def not_found_json_response
+      [404, { "Content-Type" => "application/json; charset=utf-8" }, [JSON.dump(
+        error: "Not found",
+        explanation: "Not a recognized internal call.",
       )]]
     end
 

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -356,11 +356,30 @@ module BetterErrors
               request_env["HTTP_COOKIE"] = "BetterErrors-CSRF-Token=csrfToken123"
             end
 
-            it 'returns the HTML content' do
-              expect(error_page).to receive(:do_variables).and_return(html: "<content>")
-              expect(json_body).to match(
-                'html' => '<content>',
-              )
+            context 'when the Content-Type of the request is application/json' do
+              before do
+                request_env['CONTENT_TYPE'] = 'application/json'
+              end
+
+              it 'returns JSON containing the HTML content' do
+                expect(error_page).to receive(:do_variables).and_return(html: "<content>")
+                expect(json_body).to match(
+                  'html' => '<content>',
+                )
+              end
+            end
+
+            context 'when the Content-Type of the request is application/json' do
+              before do
+                request_env['HTTP_CONTENT_TYPE'] = 'application/json'
+              end
+
+              it 'returns a JSON error' do
+                expect(json_body).to match(
+                  'error' => 'Request not acceptable',
+                  'explanation' => /did not match an acceptable content type/,
+                )
+              end
             end
           end
 


### PR DESCRIPTION
Internal calls expose exception information which might contain some sensitive information. The method name was taken from the request path and called on the `ErrorPage` instance without validation, which might have led to an insecure situation if a method was added to the `ErrorPage` class without us realizing that it would be exposed through internal calls.
