### PR TITLE
Fix path of CSRF Token cookie

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -40,7 +40,7 @@ module BetterErrors
     allow_ip! "127.0.0.0/8"
     allow_ip! "::1/128" rescue nil # windows ruby doesn't have ipv6 support
 
-    CSRF_TOKEN_COOKIE_NAME = 'BetterErrors-CSRF-Token'
+    CSRF_TOKEN_COOKIE_NAME = "BetterErrors-#{VERSION}-CSRF-Token"
 
     # A new instance of BetterErrors::Middleware
     #

--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -113,7 +113,7 @@ module BetterErrors
       response = Rack::Response.new(content, status_code, { "Content-Type" => "text/#{type}; charset=utf-8" })
 
       unless request.cookies[CSRF_TOKEN_COOKIE_NAME]
-        response.set_cookie(CSRF_TOKEN_COOKIE_NAME, value: csrf_token, httponly: true, same_site: :strict)
+        response.set_cookie(CSRF_TOKEN_COOKIE_NAME, value: csrf_token, path: "/", httponly: true, same_site: :strict)
       end
 
       # In older versions of Rack, the body returned here is actually a Rack::BodyProxy which seems to be a bug.


### PR DESCRIPTION
Fixes #476.

Since the initial Better Errors console can be opened on any path, the CSRF cookie might be set initially within a path. This would limit the visibility of the cookie, causing subsequent requests to internal Better Errors calls (which are are at `/__better_errors`) to fail because the cookie is not available in the request.

This fixes the issue by setting the CSRF Token cookie in the root path, which will make it available to all internal Better Errors requests as well as any console that will open as the result of an error thrown within the application.

In order to reduce any problems caused by CSRF tokens set with a limited path by an older version of Better Errors, the BE version is now also part of the CSRF Token cookie name. While the cookie would expire at the end of the browser session, this will eliminate the possibility that the developer will get a CSRF error after upgrading Better Errors, restarting their server, and then hitting Refresh in the browser (which is honestly a pretty likely scenario).