### PR TITLE
Fixed 'uninitialized constant BetterErrors::Middleware::VERSION' in version 2.8.2

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -40,7 +40,7 @@ module BetterErrors
     allow_ip! "127.0.0.0/8"
     allow_ip! "::1/128" rescue nil # windows ruby doesn't have ipv6 support
 
-    CSRF_TOKEN_COOKIE_NAME = "BetterErrors-#{VERSION}-CSRF-Token"
+    CSRF_TOKEN_COOKIE_NAME = "BetterErrors-#{BetterErrors::VERSION}-CSRF-Token"
 
     # A new instance of BetterErrors::Middleware
     #


### PR DESCRIPTION
Due to the changes with CSRF_TOKEN_COOKIE_NAME, when using Better Errors version 2.8.2 I would get the following error:

~/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.8/lib/bootsnap/load_path_cache/core_ext/active_support.rb:61:in `block in load_missing_constant': uninitialized constant BetterErrors::Middleware::VERSION (NameError) 56: from ~/Documents/MyProject/bin/rails:3:in `<main>

(Stack trace shorten for readability)

Downgrading to version 2.8.1 fixed the error. I believe the issue is that there is no constant named VERSION in the Middleware class, so the version number from the BetterErrors module should be used instead.