### PR TITLE
Fix CSRF_TOKEN_COOKIE_NAME wrong reference to VERSION constant

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -3,6 +3,7 @@ require "erubi"
 require "coderay"
 require "uri"
 
+require "better_errors/version"
 require "better_errors/code_formatter"
 require "better_errors/inspectable_value"
 require "better_errors/error_page"
@@ -10,7 +11,6 @@ require "better_errors/middleware"
 require "better_errors/raised_exception"
 require "better_errors/repl"
 require "better_errors/stack_frame"
-require "better_errors/version"
 
 module BetterErrors
   POSSIBLE_EDITOR_PRESETS = [

--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -40,7 +40,7 @@ module BetterErrors
     allow_ip! "127.0.0.0/8"
     allow_ip! "::1/128" rescue nil # windows ruby doesn't have ipv6 support
 
-    CSRF_TOKEN_COOKIE_NAME = "BetterErrors-#{VERSION}-CSRF-Token"
+    CSRF_TOKEN_COOKIE_NAME = "BetterErrors-#{BetterErrors::VERSION}-CSRF-Token"
 
     # A new instance of BetterErrors::Middleware
     #


### PR DESCRIPTION
It might relate to discussion at https://github.com/BetterErrors/better_errors/issues/479

After upgrading to `2.8.2` I started experiencing the following error:
```ruby
11:58:02 rails.1   | /Users/my-user/.rvm/gems/ruby-2.6.6/gems/better_errors-2.8.2/lib/better_errors/middleware.rb:43:in `<class:Middleware>‘: uninitialized constant BetterErrors::Middleware::VERSION (NameError)
11:58:02 rails.1   | 	from /Users/my-user/.rvm/gems/ruby-2.6.6/gems/better_errors-2.8.2/lib/better_errors/middleware.rb:28:in `<module:BetterErrors>'
11:58:02 rails.1   | 	from /Users/my-user/.rvm/gems/ruby-2.6.6/gems/better_errors-2.8.2/lib/better_errors/middleware.rb:7:in `<top (required)>'
11:58:02 rails.1   | 	from /Users/my-user/.rvm/gems/ruby-2.6.6/gems/better_errors-2.8.2/lib/better_errors.rb:9:in `<top (required)>'
```
I might have found the issue. I quickly looked at other places using the gem version and saw that they are using `BetterErrors::VERSION` instead of `VERSION`.

See:
https://github.com/BetterErrors/better_errors/blob/22b94ff3ec3a580e48eadb4007804aed76868905/better_errors.gemspec#L5-L13
And see:
https://github.com/BetterErrors/better_errors/blob/a31224a9bf5b71ffb9ff08104261837230181b41/lib/better_errors/middleware.rb#L166-L169

Replace the `VERSION` constant reference in an attempt to solve the issue. Please let me know if that's alright 😄 