### PR TITLE
Mention path in text response

### DIFF
--- a/lib/better_errors/templates/text.erb
+++ b/lib/better_errors/templates/text.erb
@@ -1,7 +1,10 @@
 <%== text_heading("=", "%s at %s" % [exception_type, request_path]) %>
 
-> <%== exception_message %>
-<% if backtrace_frames.any? %>
+<%== exception_message %>
+
+> To access an interactive console with this error, point your browser to: /__better_errors
+
+<% if backtrace_frames.any? -%>
 
 <%== text_heading("-", "%s, line %i" % [first_frame.pretty_path, first_frame.line]) %>
 

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -147,8 +147,8 @@ module BetterErrors
 
         it "shows the exception as-is" do
           expect(status).to eq(500)
-          expect(body).to match(/\n> Second Exception\n/)
-          expect(body).not_to match(/\n> First Exception\n/)
+          expect(body).to match(/\nSecond Exception\n/)
+          expect(body).not_to match(/\nFirst Exception\n/)
         end
       end
 


### PR DESCRIPTION
Add a simple note to the text error response that points the developer at the `/__better_errors` path so they can interact with the console.

Fixes #486 
