### PR TITLE
Fix setting editor with symbol

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -106,7 +106,7 @@ module BetterErrors
   #
   def self.editor=(editor)
     if editor.is_a? Symbol
-      @editor = Editor.for_symbol(editor)
+      @editor = Editor.editor_from_symbol(editor)
       raise(ArgumentError, "Symbol #{editor} is not a symbol in the list of supported errors.") unless editor
     elsif editor.is_a? String
       @editor = Editor.for_formatting_string(editor)

--- a/spec/better_errors_spec.rb
+++ b/spec/better_errors_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BetterErrors do
   describe ".editor" do
     context "when set to a specific value" do
       before do
-        allow(BetterErrors::Editor).to receive(:for_symbol).and_return(:editor_from_symbol)
+        allow(BetterErrors::Editor).to receive(:editor_from_symbol).and_return(:editor_from_symbol)
         allow(BetterErrors::Editor).to receive(:for_formatting_string).and_return(:editor_from_formatting_string)
         allow(BetterErrors::Editor).to receive(:for_proc).and_return(:editor_from_proc)
       end
@@ -27,9 +27,9 @@ RSpec.describe BetterErrors do
       end
 
       context "when the value is a symbol" do
-        it "uses BetterErrors::Editor.for_symbol to set the value" do
+        it "uses BetterErrors::Editor.editor_from_symbol to set the value" do
           subject.editor = :subl
-          expect(BetterErrors::Editor).to have_received(:for_symbol).with(:subl)
+          expect(BetterErrors::Editor).to have_received(:editor_from_symbol).with(:subl)
           expect(subject.editor).to eq(:editor_from_symbol)
         end
       end


### PR DESCRIPTION
The changes in commit 6591cf998872940ae64086444aa59be30f1cbe9c broke setting an editor with a symbol, when the method `Editor.for_symbol` was renamed to `Editor.editor_from_symbol`.