### PR TITLE
Add Rails 6.1 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,19 @@ jobs:
           - rails51
           - rails52
           - rails60
+          - rails61
           - rails42_haml
           - rails50_haml
           - rails51_haml
           - rails52_haml
           - rails60_haml
+          - rails61_haml
           - rails42_boc
           - rails50_boc
           - rails51_boc
           - rails52_boc
           - rails60_boc
+          - rails61_boc
           - rack
           - rack_boc
           # - pry09
@@ -50,18 +53,27 @@ jobs:
           - { ruby: 2.2,              gemfile: rails60 }
           - { ruby: 2.2,              gemfile: rails60_boc }
           - { ruby: 2.2,              gemfile: rails60_haml }
+          - { ruby: 2.2,              gemfile: rails61 }
+          - { ruby: 2.2,              gemfile: rails61_boc }
+          - { ruby: 2.2,              gemfile: rails61_haml }
           - { ruby: 2.3,              gemfile: rails42 }
           - { ruby: 2.3,              gemfile: rails42_boc }
           - { ruby: 2.3,              gemfile: rails42_haml }
           - { ruby: 2.3,              gemfile: rails60 }
           - { ruby: 2.3,              gemfile: rails60_boc }
           - { ruby: 2.3,              gemfile: rails60_haml }
+          - { ruby: 2.3,              gemfile: rails61 }
+          - { ruby: 2.3,              gemfile: rails61_boc }
+          - { ruby: 2.3,              gemfile: rails61_haml }
           - { ruby: 2.4,              gemfile: rails42 }
           - { ruby: 2.4,              gemfile: rails42_boc }
           - { ruby: 2.4,              gemfile: rails42_haml }
           - { ruby: 2.4,              gemfile: rails60 }
           - { ruby: 2.4,              gemfile: rails60_boc }
           - { ruby: 2.4,              gemfile: rails60_haml }
+          - { ruby: 2.4,              gemfile: rails61 }
+          - { ruby: 2.4,              gemfile: rails61_boc }
+          - { ruby: 2.4,              gemfile: rails61_haml }
           - { ruby: 2.5,              gemfile: rails42 }
           - { ruby: 2.5,              gemfile: rails42_boc }
           - { ruby: 2.5,              gemfile: rails42_haml }

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6.1.0rc"
+
+gem 'simplecov',      require: false
+gem 'simplecov-lcov', require: false
+
+gemspec path: "../"

--- a/gemfiles/rails61_boc.gemfile
+++ b/gemfiles/rails61_boc.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6.1.0rc"
+gem "binding_of_caller"
+
+gem 'simplecov',      require: false
+gem 'simplecov-lcov', require: false
+
+gemspec path: "../"

--- a/gemfiles/rails61_haml.gemfile
+++ b/gemfiles/rails61_haml.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6.1.0rc"
+gem "haml"
+
+gem 'simplecov',      require: false
+gem 'simplecov-lcov', require: false
+
+gemspec path: "../"


### PR DESCRIPTION
[6.1.0rc1](https://weblog.rubyonrails.org/2020/11/2/Rails-6-1-rc1-release/) is out, so let's make sure we remain compatible.
