### PR TITLE
Fix error when exception has no message string

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -78,7 +78,7 @@ module BetterErrors
     end
 
     def exception_message
-      exception.message.strip.gsub(/(\r?\n\s*\r?\n)+/, "\n")
+      exception.message&.strip&.gsub(/(\r?\n\s*\r?\n)+/, "\n")
     end
 
     def exception_hint


### PR DESCRIPTION
Encountered a scenario where exception.message is not set on the objects, in those cases it throws 500 issue.

@RobinDaugherty 