### PR TITLE
Make sassc a runtime dependency

### DIFF
--- a/better_errors.gemspec
+++ b/better_errors.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-html-matchers"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "yard"
-  s.add_development_dependency "sassc"
   # kramdown 2.1 requires Ruby 2.3+
   s.add_development_dependency "kramdown", (RUBY_VERSION < '2.3' ? '< 2.0.0' : '> 2.0.0')
   # simplecov and coveralls must not be included here. See the Gemfiles instead.
@@ -33,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubi", ">= 1.0.0"
   s.add_dependency "rouge", ">= 1.0.0"
   s.add_dependency "rack", ">= 0.9.0"
+  s.add_dependency "sassc", ">= 2.0.0"
 
   # optional dependencies:
   # s.add_dependency "binding_of_caller"


### PR DESCRIPTION
After upgrading `better_errors` from v2.9.1 to v2.10.0 our Rails app would not boot anymore in development mode. The reason is that [error_page_style.rb][error_page_style.rb] requires `sassc` which was not installed, as it was not marked as a runtime dependency.

[error_page_style.rb]: https://github.com/leoarnold/better_errors/blob/55ce4f69be35f652e4b967ad2f720ec4d6c5c72f/lib/better_errors/error_page_style.rb#L1

Fixes #516