### PR TITLE
Require sassc only in development

### DIFF
--- a/lib/better_errors/error_page_style.rb
+++ b/lib/better_errors/error_page_style.rb
@@ -1,9 +1,9 @@
-require "sassc"
-
 module BetterErrors
   # @private
   module ErrorPageStyle
     def self.compiled_css(for_deployment = false)
+      require "sassc"
+
       style_dir = File.expand_path("style", File.dirname(__FILE__))
       style_file = "#{style_dir}/main.scss"
 


### PR DESCRIPTION
This change moves the `require` call to only be invoked the first time that the Sass files are compiled. This solves the issue of applications that don't use Sass loading `better_errors` without needing to install `sassc` (see https://github.com/BetterErrors/better_errors/issues/516), and is an alternative resolution to https://github.com/BetterErrors/better_errors/pull/515.

Note: Some specs are failing for me that seem unrelated to this change, and are present even when running specs on the unmodified `master` branch. I'm not seeing tests running in CI, so a maintainer may need to verify that this fix actually works as intended.