### PR TITLE
Allow opening files in Nova editor

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -74,6 +74,7 @@ module BetterErrors
   #   * `:textmate`, `:txmt`, `:tm`
   #   * `:sublime`, `:subl`, `:st`
   #   * `:macvim`
+  #   * `:nova`
   #   * `:atom`
   #
   #   @param [Symbol] sym

--- a/lib/better_errors/editor.rb
+++ b/lib/better_errors/editor.rb
@@ -7,6 +7,7 @@ module BetterErrors
       { symbols: [:emacs, :emacsclient], sniff: /emacs/i, url: "emacs://open?url=file://%{file}&line=%{line}" },
       { symbols: [:idea], sniff: /idea/i, url: "idea://open?file=%{file}&line=%{line}" },
       { symbols: [:macvim, :mvim], sniff: /vim/i, url: "mvim://open?url=file://%{file_unencoded}&line=%{line}" },
+      { symbols: [:nova], sniff: /nova/i, url: "nova://open?path=%{file}&line=%{line}" },
       { symbols: [:rubymine], sniff: /mine/i, url: "x-mine://open?file=%{file}&line=%{line}" },
       { symbols: [:sublime, :subl, :st], sniff: /subl/i, url: "subl://open?url=file://%{file}&line=%{line}" },
       { symbols: [:textmate, :txmt, :tm], sniff: /mate/i, url: "txmt://open?url=file://%{file}&line=%{line}" },

--- a/spec/better_errors/editor_spec.rb
+++ b/spec/better_errors/editor_spec.rb
@@ -210,6 +210,16 @@ RSpec.describe BetterErrors::Editor do
       end
     end
 
+    [:nova].each do |symbol|
+      context "when symbol is '#{symbol}'" do
+        let(:symbol) { symbol }
+
+        it "uses txmt:// scheme" do
+          expect(subject.url("file", 42)).to start_with("nova://")
+        end
+      end
+    end
+
     [:sublime, :subl, :st].each do |symbol|
       context "when symbol is '#{symbol}'" do
         let(:symbol) { symbol }


### PR DESCRIPTION
Closes #518

Once this is merged, the [wiki](https://github.com/BetterErrors/better_errors/wiki/Link-to-your-editor#panic-nova) needs to be updated to indicate that Nova is now supported.

## Remove…
```md
### Panic Nova
Nova does not currently support opening files through a nova:// scheme URL.
```
## Add…

```md
## Panic Nova

Open Nova > Preferences… then click on the "Tools" button.
Under "Command Line Tool", click "Install" to install the command-line tool.

Add the following to your shell config:
````
```shell
export EDITOR="nova"
```
````
The URL is nova://open?path=%{file}&line=%{line}.
```
