### PR TITLE
Show `better_errors` even when using Turbo

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -3,6 +3,7 @@
 <head>
     <title><%= exception_type %> at <%= request_path %></title>
     <link rel="icon" href="data:;base64,=" />
+    <meta name="turbo-visit-control" content="reload" />
 </head>
 <body class="better-errors-javascript-not-loaded">
     <%# Stylesheets are placed in the <body> for Turbolinks compatibility. %>


### PR DESCRIPTION
I've enjoyed using Turbo in my Ruby projects.  What I haven't loved is the opaque `Content Missing` error that pops up when a Turbo-wrapped request throws an error.

Sure, I can right-click and dig into the request panel on my developer tools; and I do...

But wouldn't it be nice if instead of all that nonsense; errors would render directly to the screen; so I can read them with my lazy eyeballs rather than having to use my clicky-clicky-fingers?

Anway, this adds [a header to the better errors
layout](https://turbo.hotwired.dev/reference/attributes#meta-tags) which tells turbo exactly where to shove the content of this error page.

Right up our eyeballs.