### PR TITLE
Fix NoMethodError when calling rewind on rack.input with Rack 3

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -169,7 +169,7 @@ module BetterErrors
       request = Rack::Request.new(env)
       return invalid_csrf_token_json_response unless request.cookies[CSRF_TOKEN_COOKIE_NAME]
 
-      request.body.rewind
+      request.body.rewind if defined?(request.body.rewind)
       body = JSON.parse(request.body.read)
       return invalid_csrf_token_json_response unless request.cookies[CSRF_TOKEN_COOKIE_NAME] == body['csrfToken']
 


### PR DESCRIPTION
- Rack::Input is no longer required to be rewindable in Rack 3
    - https://github.com/rack/rack/blob/dff6cfd249832d32ab190e6d20605bce0d6c702d/UPGRADE-GUIDE.md#rackinput-is-no-longer-required-to-be-rewindable
- When using better_errors with Rack 3, `NoMethodError` is raised due to trying rewind on rack.input
        ![image](https://github.com/BetterErrors/better_errors/assets/881478/fc28470c-962a-441b-8684-09f44c93d5dd)
- It should be checked `#rewind` is implemented before calling.